### PR TITLE
Import tables directly instead of schema

### DIFF
--- a/apps/kdx/src/app/[locale]/team/invite/[id]/page.tsx
+++ b/apps/kdx/src/app/[locale]/team/invite/[id]/page.tsx
@@ -3,7 +3,7 @@ import { notFound, redirect } from "next/navigation";
 import { auth } from "@kdx/auth";
 import { eq } from "@kdx/db";
 import { db } from "@kdx/db/client";
-import * as schema from "@kdx/db/schema";
+import { invitations, users } from "@kdx/db/schema";
 
 import { api } from "~/trpc/server";
 
@@ -15,7 +15,7 @@ export default async function InvitePage({
   const { id: invitationId } = params;
 
   const invitation = await db.query.invitations.findFirst({
-    where: eq(schema.invitations.id, invitationId),
+    where: eq(invitations.id, invitationId),
   });
   if (!invitation) return notFound();
 
@@ -24,7 +24,7 @@ export default async function InvitePage({
     let path = `/signup?invite=${invitationId}`;
 
     const existingUser = await db.query.users.findFirst({
-      where: eq(schema.users.email, invitation.email),
+      where: eq(users.email, invitation.email),
       columns: { id: true },
     });
 

--- a/apps/kdx/src/app/[locale]/team/notifications/_components/data-table-notifications.tsx
+++ b/apps/kdx/src/app/[locale]/team/notifications/_components/data-table-notifications.tsx
@@ -6,7 +6,7 @@ import { MdEmail } from "react-icons/md";
 import type { RouterOutputs } from "@kdx/api";
 import type { DataTableFilterField } from "@kdx/ui/data-table/advanced/types";
 import type { FixedColumnsType } from "@kdx/ui/data-table/data-table";
-import * as schema from "@kdx/db/schema";
+import { notifications } from "@kdx/db/schema";
 import { useI18n } from "@kdx/locales/client";
 import { DataTableAdvancedToolbar } from "@kdx/ui/data-table/advanced/data-table-advanced-toolbar";
 import { DataTable } from "@kdx/ui/data-table/data-table";
@@ -47,7 +47,7 @@ export function DataTableNotifications({
     {
       label: t("Channel"),
       value: "channel",
-      options: schema.notifications.channel.enumValues.map((channel) => ({
+      options: notifications.channel.enumValues.map((channel) => ({
         label: channel[0]?.toUpperCase() + channel.slice(1),
         value: channel,
         icon: MdEmail,

--- a/apps/kdx/src/app/[locale]/team/notifications/preview-email/[id]/route.ts
+++ b/apps/kdx/src/app/[locale]/team/notifications/preview-email/[id]/route.ts
@@ -3,12 +3,12 @@ import { notFound, redirect } from "next/navigation";
 import { auth } from "@kdx/auth";
 import { eq, sql } from "@kdx/db";
 import { db } from "@kdx/db/client";
-import * as schema from "@kdx/db/schema";
+import { usersToTeams } from "@kdx/db/schema";
 
 const allTeamIdsForUserQuery = db
-  .select({ id: schema.usersToTeams.teamId })
-  .from(schema.usersToTeams)
-  .where(eq(schema.usersToTeams.userId, sql.placeholder("userId")));
+  .select({ id: usersToTeams.teamId })
+  .from(usersToTeams)
+  .where(eq(usersToTeams.userId, sql.placeholder("userId")));
 
 const prepared = db.query.notifications
   .findFirst({

--- a/apps/kdx/src/app/[locale]/team/settings/roles/layout.tsx
+++ b/apps/kdx/src/app/[locale]/team/settings/roles/layout.tsx
@@ -4,7 +4,7 @@ import { redirect } from "next/navigation";
 import { auth } from "@kdx/auth";
 import { eq } from "@kdx/db";
 import { db } from "@kdx/db/client";
-import * as schema from "@kdx/db/schema";
+import { teams } from "@kdx/db/schema";
 import { getI18n } from "@kdx/locales/server";
 
 import { AppSwitcher } from "~/app/[locale]/_components/app-switcher";
@@ -18,7 +18,7 @@ export default async function RolesLayout({
   if (!user) redirect("/");
 
   const team = await db.query.teams.findFirst({
-    where: eq(schema.teams.id, user.activeTeamId),
+    where: eq(teams.id, user.activeTeamId),
     columns: {
       ownerId: true,
     },

--- a/packages/api/src/internal/notificationCenter.ts
+++ b/packages/api/src/internal/notificationCenter.ts
@@ -1,7 +1,7 @@
 import { render } from "@react-email/render";
 
 import { db } from "@kdx/db/client";
-import * as schema from "@kdx/db/schema";
+import { notifications } from "@kdx/db/schema";
 
 import type { resend } from "../utils/email";
 
@@ -31,7 +31,7 @@ export async function sendNotifications({
   });
   if (!user) throw new Error("Could not find user to send notification");
 
-  const sent: (typeof schema.notifications.$inferInsert)[] = [];
+  const sent: (typeof notifications.$inferInsert)[] = [];
   for (const channel of channels) {
     // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
     if (channel.type === "EMAIL") {
@@ -50,5 +50,5 @@ export async function sendNotifications({
     }
   }
 
-  if (sent.length) await db.insert(schema.notifications).values(sent);
+  if (sent.length) await db.insert(notifications).values(sent);
 }

--- a/packages/api/src/procedures.ts
+++ b/packages/api/src/procedures.ts
@@ -2,7 +2,7 @@ import type { inferProcedureBuilderResolverOptions } from "@trpc/server";
 import { TRPCError } from "@trpc/server";
 
 import { eq } from "@kdx/db";
-import * as schema from "@kdx/db/schema";
+import { teams } from "@kdx/db/schema";
 
 import { t } from "./trpc";
 
@@ -47,7 +47,7 @@ export type TProtectedProcedureContext = inferProcedureBuilderResolverOptions<
 export const isTeamOwnerProcedure = protectedProcedure.use(
   async ({ ctx, next }) => {
     const team = await ctx.db.query.teams.findFirst({
-      where: eq(schema.teams.id, ctx.session.user.activeTeamId),
+      where: eq(teams.id, ctx.session.user.activeTeamId),
       columns: {
         id: true,
         ownerId: true,

--- a/packages/api/src/routers/app/calendar/cancel.handler.ts
+++ b/packages/api/src/routers/app/calendar/cancel.handler.ts
@@ -3,7 +3,11 @@ import { RRule, rrulestr } from "rrule";
 
 import type { TCancelInputSchema } from "@kdx/validators/trpc/app/calendar";
 import { and, eq, gte, inArray } from "@kdx/db";
-import * as schema from "@kdx/db/schema";
+import {
+  eventCancellations,
+  eventExceptions,
+  eventMasters,
+} from "@kdx/db/schema";
 
 import type { TProtectedProcedureContext } from "../../../procedures";
 
@@ -31,10 +35,10 @@ export const cancelHandler = async ({ ctx, input }: CancelOptions) => {
           });
         }
         await tx
-          .delete(schema.eventExceptions)
+          .delete(eventExceptions)
           // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-          .where(eq(schema.eventExceptions.id, input.eventExceptionId!));
-        return await tx.insert(schema.eventCancellations).values({
+          .where(eq(eventExceptions.id, input.eventExceptionId!));
+        return await tx.insert(eventCancellations).values({
           eventMasterId: toDeleteException.eventMasterId,
           originalDate: toDeleteException.originalDate,
         });
@@ -42,7 +46,7 @@ export const cancelHandler = async ({ ctx, input }: CancelOptions) => {
       return;
     }
 
-    await ctx.db.insert(schema.eventCancellations).values({
+    await ctx.db.insert(eventCancellations).values({
       eventMasterId: input.eventMasterId,
       originalDate: input.date,
     });
@@ -51,25 +55,25 @@ export const cancelHandler = async ({ ctx, input }: CancelOptions) => {
     await ctx.db.transaction(async (tx) => {
       if (input.eventExceptionId) {
         const allEventMastersIdsForThisTeamQuery = ctx.db
-          .select({ id: schema.eventMasters.id })
-          .from(schema.eventMasters)
-          .where(eq(schema.eventMasters.teamId, ctx.session.user.activeTeamId));
+          .select({ id: eventMasters.id })
+          .from(eventMasters)
+          .where(eq(eventMasters.teamId, ctx.session.user.activeTeamId));
 
         await tx
-          .delete(schema.eventExceptions)
+          .delete(eventExceptions)
           .where(
             and(
               inArray(
-                schema.eventExceptions.eventMasterId,
+                eventExceptions.eventMasterId,
                 allEventMastersIdsForThisTeamQuery,
               ),
-              eq(schema.eventExceptions.id, input.eventExceptionId),
-              gte(schema.eventExceptions.newDate, input.date),
+              eq(eventExceptions.id, input.eventExceptionId),
+              gte(eventExceptions.newDate, input.date),
             ),
           );
       }
       const eventMaster = await tx.query.eventMasters.findFirst({
-        where: eq(schema.eventMasters.id, input.eventMasterId),
+        where: eq(eventMasters.id, input.eventMasterId),
         columns: {
           rule: true,
           dateStart: true,
@@ -86,25 +90,25 @@ export const cancelHandler = async ({ ctx, input }: CancelOptions) => {
       const penultimateOccurence = occurences[occurences.length - 2];
       if (!penultimateOccurence)
         await tx
-          .delete(schema.eventMasters)
-          .where(eq(schema.eventMasters.id, input.eventMasterId));
+          .delete(eventMasters)
+          .where(eq(eventMasters.id, input.eventMasterId));
 
       const options = RRule.parseString(eventMaster.rule);
       options.until = penultimateOccurence;
 
       return await tx
-        .update(schema.eventMasters)
+        .update(eventMasters)
         .set({
           dateUntil: penultimateOccurence,
           rule: new RRule(options).toString(),
         })
-        .where(eq(schema.eventMasters.id, input.eventMasterId));
+        .where(eq(eventMasters.id, input.eventMasterId));
     });
     return;
   } else {
     await ctx.db
-      .delete(schema.eventMasters)
-      .where(eq(schema.eventMasters.id, input.eventMasterId));
+      .delete(eventMasters)
+      .where(eq(eventMasters.id, input.eventMasterId));
     return;
   }
 };

--- a/packages/api/src/routers/app/calendar/create.handler.ts
+++ b/packages/api/src/routers/app/calendar/create.handler.ts
@@ -1,7 +1,7 @@
 import { RRule } from "rrule";
 
 import type { TCreateInputSchema } from "@kdx/validators/trpc/app/calendar";
-import * as schema from "@kdx/db/schema";
+import { eventMasters } from "@kdx/db/schema";
 
 import type { TProtectedProcedureContext } from "../../../procedures";
 
@@ -11,7 +11,7 @@ interface CreateOptions {
 }
 
 export const createHandler = async ({ ctx, input }: CreateOptions) => {
-  await ctx.db.insert(schema.eventMasters).values({
+  await ctx.db.insert(eventMasters).values({
     title: input.title,
     description: input.description,
     rule: new RRule({

--- a/packages/api/src/routers/app/calendar/edit.handler.ts
+++ b/packages/api/src/routers/app/calendar/edit.handler.ts
@@ -5,7 +5,7 @@ import type { TEditInputSchema } from "@kdx/validators/trpc/app/calendar";
 import dayjs from "@kdx/dayjs";
 import { and, eq, gt, gte, inArray } from "@kdx/db";
 import { nanoid } from "@kdx/db/nanoid";
-import * as schema from "@kdx/db/schema";
+import { eventExceptions, eventMasters } from "@kdx/db/schema";
 
 import type { TProtectedProcedureContext } from "../../../procedures";
 
@@ -16,9 +16,9 @@ interface EditOptions {
 
 export const editHandler = async ({ ctx, input }: EditOptions) => {
   const allEventMastersIdsForThisTeamQuery = ctx.db
-    .select({ id: schema.eventMasters.id })
-    .from(schema.eventMasters)
-    .where(eq(schema.eventMasters.teamId, ctx.session.user.activeTeamId));
+    .select({ id: eventMasters.id })
+    .from(eventMasters)
+    .where(eq(eventMasters.teamId, ctx.session.user.activeTeamId));
 
   if (input.editDefinition === "single") {
     //* Havemos description, title, from e selectedTimestamp.
@@ -31,7 +31,7 @@ export const editHandler = async ({ ctx, input }: EditOptions) => {
       //* Aqui, o usuário pode alterar o title e o description ou o from da exceção.
 
       await ctx.db
-        .update(schema.eventExceptions)
+        .update(eventExceptions)
         .set({
           newDate: input.from,
           title: input.title,
@@ -40,11 +40,11 @@ export const editHandler = async ({ ctx, input }: EditOptions) => {
         .where(
           and(
             inArray(
-              schema.eventExceptions.eventMasterId,
+              eventExceptions.eventMasterId,
               allEventMastersIdsForThisTeamQuery,
             ),
-            eq(schema.eventExceptions.id, input.eventExceptionId),
-            eq(schema.eventExceptions.newDate, input.selectedTimestamp),
+            eq(eventExceptions.id, input.eventExceptionId),
+            eq(eventExceptions.newDate, input.selectedTimestamp),
           ),
         );
       return;
@@ -87,7 +87,7 @@ export const editHandler = async ({ ctx, input }: EditOptions) => {
     //* Para fazer isso, temos que criar uma NOVA EXCEÇÃO.
     if (input.title !== undefined || input.description !== undefined) {
       //* Se tivermos title ou description, criamos um eventInfo e também uma exceção.
-      await ctx.db.insert(schema.eventExceptions).values({
+      await ctx.db.insert(eventExceptions).values({
         eventMasterId: eventMaster.id,
         originalDate: foundTimestamp,
         newDate: input.from ?? foundTimestamp,
@@ -99,7 +99,7 @@ export const editHandler = async ({ ctx, input }: EditOptions) => {
     }
     //* Se não tivermos title nem description, ainda temos o from. Criamos uma exceção sem eventInfo.
     else {
-      await ctx.db.insert(schema.eventExceptions).values({
+      await ctx.db.insert(eventExceptions).values({
         eventMasterId: eventMaster.id,
         originalDate: foundTimestamp,
         newDate: input.from ?? foundTimestamp,
@@ -126,11 +126,11 @@ export const editHandler = async ({ ctx, input }: EditOptions) => {
       );
       if (shouldDeleteFutureExceptions)
         await tx
-          .delete(schema.eventExceptions)
+          .delete(eventExceptions)
           .where(
             and(
-              eq(schema.eventExceptions.eventMasterId, input.eventMasterId),
-              gte(schema.eventExceptions.newDate, input.selectedTimestamp),
+              eq(eventExceptions.eventMasterId, input.eventMasterId),
+              gte(eventExceptions.newDate, input.selectedTimestamp),
             ),
           );
 
@@ -171,7 +171,7 @@ export const editHandler = async ({ ctx, input }: EditOptions) => {
 
         //! NO SPLIT REQUIRED !!
         await tx
-          .update(schema.eventMasters)
+          .update(eventMasters)
           .set({
             title: input.title,
             description: input.description,
@@ -191,28 +191,28 @@ export const editHandler = async ({ ctx, input }: EditOptions) => {
           })
           .where(
             and(
-              eq(schema.eventMasters.id, input.eventMasterId),
-              eq(schema.eventMasters.teamId, ctx.session.user.activeTeamId),
+              eq(eventMasters.id, input.eventMasterId),
+              eq(eventMasters.teamId, ctx.session.user.activeTeamId),
             ),
           );
         if (shouldDeleteFutureExceptions) return;
         if (input.title ?? input.description)
           await tx
-            .update(schema.eventExceptions)
+            .update(eventExceptions)
             .set({
               title: input.title ? null : undefined,
               description: input.description ? null : undefined,
             })
             .where(
               and(
-                eq(schema.eventExceptions.eventMasterId, input.eventMasterId),
-                eq(schema.eventMasters.teamId, ctx.session.user.activeTeamId),
+                eq(eventExceptions.eventMasterId, input.eventMasterId),
+                eq(eventMasters.teamId, ctx.session.user.activeTeamId),
               ),
             );
         return;
       }
       await tx
-        .update(schema.eventMasters)
+        .update(eventMasters)
         .set({
           dateUntil: previousOccurence,
           rule: new RRule({
@@ -226,13 +226,13 @@ export const editHandler = async ({ ctx, input }: EditOptions) => {
         })
         .where(
           and(
-            eq(schema.eventMasters.id, input.eventMasterId),
-            eq(schema.eventMasters.teamId, ctx.session.user.activeTeamId),
+            eq(eventMasters.id, input.eventMasterId),
+            eq(eventMasters.teamId, ctx.session.user.activeTeamId),
           ),
         );
 
       const newMasterId = nanoid();
-      await tx.insert(schema.eventMasters).values({
+      await tx.insert(eventMasters).values({
         id: newMasterId,
         teamId: ctx.session.user.activeTeamId,
         dateStart: input.from ?? input.selectedTimestamp,
@@ -254,7 +254,7 @@ export const editHandler = async ({ ctx, input }: EditOptions) => {
 
       if (!shouldDeleteFutureExceptions) {
         await tx
-          .update(schema.eventExceptions)
+          .update(eventExceptions)
           .set({
             title: input.title ? null : undefined,
             description: input.description ? null : undefined,
@@ -263,11 +263,11 @@ export const editHandler = async ({ ctx, input }: EditOptions) => {
           .where(
             and(
               inArray(
-                schema.eventExceptions.eventMasterId,
+                eventExceptions.eventMasterId,
                 allEventMastersIdsForThisTeamQuery,
               ),
-              eq(schema.eventExceptions.eventMasterId, oldMaster.id),
-              gte(schema.eventExceptions.newDate, input.selectedTimestamp),
+              eq(eventExceptions.eventMasterId, oldMaster.id),
+              gte(eventExceptions.newDate, input.selectedTimestamp),
             ),
           );
       }
@@ -335,7 +335,7 @@ export const editHandler = async ({ ctx, input }: EditOptions) => {
       })();
 
       await tx
-        .update(schema.eventMasters)
+        .update(eventMasters)
         .set({
           title: input.title,
           description: input.description,
@@ -345,21 +345,21 @@ export const editHandler = async ({ ctx, input }: EditOptions) => {
         })
         .where(
           and(
-            eq(schema.eventMasters.id, input.eventMasterId),
-            eq(schema.eventMasters.teamId, ctx.session.user.activeTeamId),
+            eq(eventMasters.id, input.eventMasterId),
+            eq(eventMasters.teamId, ctx.session.user.activeTeamId),
           ),
         );
 
       if (input.from ?? input.until) {
         await tx
-          .delete(schema.eventExceptions)
+          .delete(eventExceptions)
           .where(
             and(
-              eq(schema.eventExceptions.eventMasterId, input.eventMasterId),
+              eq(eventExceptions.eventMasterId, input.eventMasterId),
               input.from
                 ? undefined
                 : input.until
-                  ? gt(schema.eventExceptions.newDate, input.until)
+                  ? gt(eventExceptions.newDate, input.until)
                   : undefined,
             ),
           );

--- a/packages/api/src/routers/app/calendar/getAll.handler.ts
+++ b/packages/api/src/routers/app/calendar/getAll.handler.ts
@@ -3,7 +3,11 @@ import { rrulestr } from "rrule";
 import type { TGetAllInputSchema } from "@kdx/validators/trpc/app/calendar";
 import dayjs from "@kdx/dayjs";
 import { and, eq, gte, lte, or } from "@kdx/db";
-import * as schema from "@kdx/db/schema";
+import {
+  eventCancellations,
+  eventExceptions,
+  eventMasters,
+} from "@kdx/db/schema";
 
 import type { TProtectedProcedureContext } from "../../../procedures";
 
@@ -25,7 +29,7 @@ export const getAllHandler = async ({
   ctx,
   input,
 }: GetAllCalendarTasksOptions) => {
-  const eventMasters = await ctx.db.query.eventMasters.findMany({
+  const _eventMasters = await ctx.db.query.eventMasters.findMany({
     where: (eventMasters, { and, gte, eq, or, lte, isNull }) =>
       and(
         eq(eventMasters.teamId, ctx.session.user.activeTeamId),
@@ -40,23 +44,23 @@ export const getAllHandler = async ({
   });
 
   //Handling Exceptions and Cancelations
-  const eventExceptions = await ctx.db
+  const _eventExceptions = await ctx.db
     .select({
-      id: schema.eventExceptions.id,
-      eventMasterId: schema.eventExceptions.eventMasterId,
-      originalDate: schema.eventExceptions.originalDate,
-      newDate: schema.eventExceptions.newDate,
-      title: schema.eventExceptions.title,
-      description: schema.eventExceptions.description,
-      rule: schema.eventMasters.rule,
-      eventMasterTitle: schema.eventMasters.title,
-      eventMasterDescription: schema.eventMasters.description,
-      eventMasterRule: schema.eventMasters.rule,
+      id: eventExceptions.id,
+      eventMasterId: eventExceptions.eventMasterId,
+      originalDate: eventExceptions.originalDate,
+      newDate: eventExceptions.newDate,
+      title: eventExceptions.title,
+      description: eventExceptions.description,
+      rule: eventMasters.rule,
+      eventMasterTitle: eventMasters.title,
+      eventMasterDescription: eventMasters.description,
+      eventMasterRule: eventMasters.rule,
     })
-    .from(schema.eventExceptions)
+    .from(eventExceptions)
     .where((eventExceptions) =>
       and(
-        eq(schema.eventMasters.teamId, ctx.session.user.activeTeamId),
+        eq(eventMasters.teamId, ctx.session.user.activeTeamId),
         or(
           and(
             gte(eventExceptions.originalDate, input.dateStart),
@@ -70,19 +74,19 @@ export const getAllHandler = async ({
       ),
     )
     .innerJoin(
-      schema.eventMasters,
-      eq(schema.eventMasters.id, schema.eventExceptions.eventMasterId),
+      eventMasters,
+      eq(eventMasters.id, eventExceptions.eventMasterId),
     );
 
-  const eventCancelations = await ctx.db
+  const _eventCancelations = await ctx.db
     .select({
-      originalDate: schema.eventCancellations.originalDate,
-      eventMasterId: schema.eventMasters.id,
+      originalDate: eventCancellations.originalDate,
+      eventMasterId: eventMasters.id,
     })
-    .from(schema.eventCancellations)
+    .from(eventCancellations)
     .where((eventCancellations) =>
       and(
-        eq(schema.eventMasters.teamId, ctx.session.user.activeTeamId),
+        eq(eventMasters.teamId, ctx.session.user.activeTeamId),
         and(
           gte(eventCancellations.originalDate, input.dateStart),
           lte(eventCancellations.originalDate, input.dateEnd),
@@ -90,15 +94,15 @@ export const getAllHandler = async ({
       ),
     )
     .innerJoin(
-      schema.eventMasters,
-      eq(schema.eventMasters.id, schema.eventCancellations.eventMasterId),
+      eventMasters,
+      eq(eventMasters.id, eventCancellations.eventMasterId),
     );
 
   //* We have all needed data. Now, let's add all masters and exceptions to calendarTasks.
 
   let calendarTasks: CalendarTask[] = [];
 
-  for (const eventMaster of eventMasters) {
+  for (const eventMaster of _eventMasters) {
     const rrule = rrulestr(eventMaster.rule);
     const allDates = rrule.between(input.dateStart, input.dateEnd, true);
 
@@ -113,7 +117,7 @@ export const getAllHandler = async ({
       });
   }
 
-  for (const eventException of eventExceptions)
+  for (const eventException of _eventExceptions)
     calendarTasks.push({
       eventMasterId: eventException.eventMasterId,
       eventExceptionId: eventException.id,
@@ -142,7 +146,7 @@ export const getAllHandler = async ({
         return calendarTask;
       }
       //Cuidar de cancelamentos -> deletar os advindos do master
-      const foundCancelation = eventCancelations.some(
+      const foundCancelation = _eventCancelations.some(
         (x) =>
           x.eventMasterId === calendarTask.eventMasterId &&
           dayjs(x.originalDate).isSame(calendarTask.date),

--- a/packages/api/src/routers/app/calendar/nuke.handler.ts
+++ b/packages/api/src/routers/app/calendar/nuke.handler.ts
@@ -1,7 +1,7 @@
 import { TRPCError } from "@trpc/server";
 
 import { eq } from "@kdx/db";
-import * as schema from "@kdx/db/schema";
+import { eventMasters } from "@kdx/db/schema";
 import { authorizedEmails } from "@kdx/shared";
 
 import type { TProtectedProcedureContext } from "../../../procedures";
@@ -18,6 +18,6 @@ export const nukeHandler = async ({ ctx }: NukeOptions) => {
     });
 
   await ctx.db
-    .delete(schema.eventMasters)
-    .where(eq(schema.eventMasters.teamId, ctx.session.user.activeTeamId));
+    .delete(eventMasters)
+    .where(eq(eventMasters.teamId, ctx.session.user.activeTeamId));
 };

--- a/packages/api/src/routers/app/installApp.handler.ts
+++ b/packages/api/src/routers/app/installApp.handler.ts
@@ -4,7 +4,14 @@ import type { TInstallAppInputSchema } from "@kdx/validators/trpc/app";
 import { and, eq } from "@kdx/db";
 import { appRoles_defaultTree } from "@kdx/db/constants";
 import { nanoid } from "@kdx/db/nanoid";
-import * as schema from "@kdx/db/schema";
+import {
+  appPermissionsToTeamAppRoles,
+  apps,
+  appsToTeams,
+  teamAppRoles,
+  teamAppRolesToUsers,
+  teams,
+} from "@kdx/db/schema";
 import { appIdToAdminRole_defaultIdMap } from "@kdx/shared";
 
 import type { TIsTeamOwnerProcedureContext } from "../../procedures";
@@ -17,14 +24,14 @@ interface InstallAppOptions {
 
 export const installAppHandler = async ({ ctx, input }: InstallAppOptions) => {
   const installed = await ctx.db
-    .select({ id: schema.apps.id })
-    .from(schema.apps)
-    .innerJoin(schema.appsToTeams, eq(schema.appsToTeams.appId, schema.apps.id))
-    .innerJoin(schema.teams, eq(schema.teams.id, schema.appsToTeams.teamId))
+    .select({ id: apps.id })
+    .from(apps)
+    .innerJoin(appsToTeams, eq(appsToTeams.appId, apps.id))
+    .innerJoin(teams, eq(teams.id, appsToTeams.teamId))
     .where(
       and(
-        eq(schema.teams.id, ctx.session.user.activeTeamId),
-        eq(schema.apps.id, input.appId),
+        eq(teams.id, ctx.session.user.activeTeamId),
+        eq(apps.id, input.appId),
       ),
     )
     .then((res) => res[0]);
@@ -36,7 +43,7 @@ export const installAppHandler = async ({ ctx, input }: InstallAppOptions) => {
     });
 
   await ctx.db.transaction(async (tx) => {
-    await tx.insert(schema.appsToTeams).values({
+    await tx.insert(appsToTeams).values({
       appId: input.appId,
       teamId: ctx.session.user.activeTeamId,
     });
@@ -51,9 +58,9 @@ export const installAppHandler = async ({ ctx, input }: InstallAppOptions) => {
         appRoleDefaultId: defaultAppRole.id,
         teamId: ctx.session.user.activeTeamId,
       }),
-    ) satisfies (typeof schema.teamAppRoles.$inferInsert)[];
+    ) satisfies (typeof teamAppRoles.$inferInsert)[];
 
-    await tx.insert(schema.teamAppRoles).values(toCreateDefaultAppRoles);
+    await tx.insert(teamAppRoles).values(toCreateDefaultAppRoles);
 
     //? 2. Connect the permissions to the newly created roles if any exists
     const toAddPermissions = toCreateDefaultAppRoles.flatMap((role) =>
@@ -61,12 +68,10 @@ export const installAppHandler = async ({ ctx, input }: InstallAppOptions) => {
         appPermissionId: permission.id,
         teamAppRoleId: role.id,
       })),
-    ) satisfies (typeof schema.appPermissionsToTeamAppRoles.$inferInsert)[];
+    ) satisfies (typeof appPermissionsToTeamAppRoles.$inferInsert)[];
 
     if (toAddPermissions.length > 0)
-      await tx
-        .insert(schema.appPermissionsToTeamAppRoles)
-        .values(toAddPermissions);
+      await tx.insert(appPermissionsToTeamAppRoles).values(toAddPermissions);
 
     //?3. Add the user to the admin role for the app
     const adminRoleForApp = toCreateDefaultAppRoles.find(
@@ -81,7 +86,7 @@ export const installAppHandler = async ({ ctx, input }: InstallAppOptions) => {
         message: "Admin role not found",
       });
 
-    await tx.insert(schema.teamAppRolesToUsers).values({
+    await tx.insert(teamAppRolesToUsers).values({
       teamAppRoleId: adminRoleForApp.id,
       userId: ctx.session.user.id,
     });

--- a/packages/api/src/routers/app/kodixCare/doCheckoutForShift.handler.ts
+++ b/packages/api/src/routers/app/kodixCare/doCheckoutForShift.handler.ts
@@ -3,7 +3,7 @@ import { TRPCError } from "@trpc/server";
 import type { TDoCheckoutForShiftInputSchema } from "@kdx/validators/trpc/app/kodixCare";
 import dayjs from "@kdx/dayjs";
 import { eq } from "@kdx/db";
-import * as schema from "@kdx/db/schema";
+import { careShifts } from "@kdx/db/schema";
 
 import type { TProtectedProcedureContext } from "../../../procedures";
 import { getCurrentCareShiftHandler } from "./getCurrentCareShift.handler";
@@ -36,7 +36,7 @@ export const doCheckoutForShiftHandler = async ({
     });
 
   await ctx.db
-    .update(schema.careShifts)
+    .update(careShifts)
     .set({ checkOut: input.date })
-    .where(eq(schema.careShifts.id, currentShift.id));
+    .where(eq(careShifts.id, currentShift.id));
 };

--- a/packages/api/src/routers/app/kodixCare/getCareTasks.handler.ts
+++ b/packages/api/src/routers/app/kodixCare/getCareTasks.handler.ts
@@ -1,6 +1,6 @@
 import type { TGetCareTasksInputSchema } from "@kdx/validators/trpc/app/kodixCare";
 import dayjs from "@kdx/dayjs";
-import * as schema from "@kdx/db/schema";
+import { eventMasters } from "@kdx/db/schema";
 import { kodixCareAppId } from "@kdx/shared";
 
 import type { TProtectedProcedureContext } from "../../../procedures";
@@ -22,7 +22,7 @@ export const getCareTasksHandler = async ({
     await ctx.db.query.careTasks.findMany({
       where: (careTask, { gte, lte, eq, and }) =>
         and(
-          eq(schema.eventMasters.teamId, ctx.session.user.activeTeamId),
+          eq(eventMasters.teamId, ctx.session.user.activeTeamId),
           gte(careTask.eventDate, input.dateStart),
           lte(careTask.eventDate, input.dateEnd),
         ),

--- a/packages/api/src/routers/app/kodixCare/saveCareTask.handler.ts
+++ b/packages/api/src/routers/app/kodixCare/saveCareTask.handler.ts
@@ -1,6 +1,6 @@
 import type { TSaveCareTaskInputSchema } from "@kdx/validators/trpc/app/kodixCare";
 import { eq } from "@kdx/db";
-import * as schema from "@kdx/db/schema";
+import { careTasks } from "@kdx/db/schema";
 
 import type { TProtectedProcedureContext } from "../../../procedures";
 
@@ -15,11 +15,11 @@ export const saveCareTaskHandler = async ({
   input,
 }: SaveCareTaskOptions) => {
   await ctx.db
-    .update(schema.careTasks)
+    .update(careTasks)
     .set({
       doneByUserId: input.doneAt === null ? null : input.doneByUserId, //? if doneAt is null, doneByUserId should be null
       doneAt: input.doneByUserId === null ? null : input.doneAt,
       details: input.details,
     })
-    .where(eq(schema.careTasks.id, input.id));
+    .where(eq(careTasks.id, input.id));
 };

--- a/packages/api/src/routers/app/kodixCare/toggleShift.handler.ts
+++ b/packages/api/src/routers/app/kodixCare/toggleShift.handler.ts
@@ -3,6 +3,7 @@ import { TRPCError } from "@trpc/server";
 import dayjs from "@kdx/dayjs";
 import { eq } from "@kdx/db";
 import { nanoid } from "@kdx/db/nanoid";
+import { careShifts } from "@kdx/db/schema";
 import WarnPreviousShiftNotEnded from "@kdx/react-email/warn-previous-shift-not-ended";
 import { kodixCareAppId, kodixNotificationFromEmail } from "@kdx/shared";
 
@@ -11,7 +12,6 @@ import { resend } from "../../../utils/email";
 import { getConfigHandler } from "../getConfig.handler";
 import { getCurrentCareShiftHandler } from "./getCurrentCareShift.handler";
 import { cloneCalendarTasksToCareTasks } from "./utils";
-import { careShifts } from "@kdx/db/schema";
 
 interface ToggleShiftOptions {
   ctx: TProtectedProcedureContext;

--- a/packages/api/src/routers/app/kodixCare/utils/index.ts
+++ b/packages/api/src/routers/app/kodixCare/utils/index.ts
@@ -1,4 +1,4 @@
-import * as schema from "@kdx/db/schema";
+import { careTasks } from "@kdx/db/schema";
 import { kodixCareAppId } from "@kdx/shared";
 
 import type { TProtectedProcedureContext } from "../../../../procedures";
@@ -25,7 +25,7 @@ export async function cloneCalendarTasksToCareTasks({
   });
 
   if (calendarTasks.length > 0)
-    await ctx.db.insert(schema.careTasks).values(
+    await ctx.db.insert(careTasks).values(
       calendarTasks.map((calendarTask) => ({
         careShiftId: careShiftId,
         teamId: ctx.session.user.activeTeamId,

--- a/packages/api/src/routers/app/saveConfig.handler.ts
+++ b/packages/api/src/routers/app/saveConfig.handler.ts
@@ -1,6 +1,6 @@
 import type { TSaveConfigInput } from "@kdx/validators/trpc/app";
 import { and, eq } from "@kdx/db";
-import * as schema from "@kdx/db/schema";
+import { appTeamConfigs } from "@kdx/db/schema";
 import { appIdToAppTeamConfigSchema } from "@kdx/validators";
 
 import type { TProtectedProcedureContext } from "../../procedures";
@@ -25,7 +25,7 @@ export const saveConfigHandler = async ({ ctx, input }: SaveConfigOptions) => {
   const configSchema = appIdToAppTeamConfigSchema[input.appId];
   if (existingConfig) {
     return await ctx.db
-      .update(schema.appTeamConfigs)
+      .update(appTeamConfigs)
       .set({
         config: {
           ...configSchema.parse(existingConfig.config),
@@ -34,8 +34,8 @@ export const saveConfigHandler = async ({ ctx, input }: SaveConfigOptions) => {
       })
       .where(
         and(
-          eq(schema.appTeamConfigs.appId, input.appId),
-          eq(schema.appTeamConfigs.teamId, ctx.session.user.activeTeamId),
+          eq(appTeamConfigs.appId, input.appId),
+          eq(appTeamConfigs.teamId, ctx.session.user.activeTeamId),
         ),
       );
   }
@@ -43,7 +43,7 @@ export const saveConfigHandler = async ({ ctx, input }: SaveConfigOptions) => {
   //new record. We need to validate the whole config without partial()
   const parsedInput = configSchema.parse(input.config);
 
-  await ctx.db.insert(schema.appTeamConfigs).values({
+  await ctx.db.insert(appTeamConfigs).values({
     config: parsedInput,
     teamId: ctx.session.user.activeTeamId,
     appId: input.appId,

--- a/packages/api/src/routers/app/todo/create.handler.ts
+++ b/packages/api/src/routers/app/todo/create.handler.ts
@@ -1,5 +1,5 @@
 import type { TCreateInputSchema } from "@kdx/validators/trpc/app/todo";
-import * as schema from "@kdx/db/schema";
+import { todos } from "@kdx/db/schema";
 
 import type { TProtectedProcedureContext } from "../../../procedures";
 
@@ -9,7 +9,7 @@ interface CreateOptions {
 }
 
 export const createHandler = async ({ ctx, input }: CreateOptions) => {
-  await ctx.db.insert(schema.todos).values({
+  await ctx.db.insert(todos).values({
     assignedToUserId: input.assignedToUserId,
     teamId: ctx.session.user.activeTeamId,
     title: input.title,

--- a/packages/api/src/routers/app/todo/update.handler.ts
+++ b/packages/api/src/routers/app/todo/update.handler.ts
@@ -1,6 +1,6 @@
 import type { TUpdateInputSchema } from "@kdx/validators/trpc/app/todo";
 import { and, eq } from "@kdx/db";
-import * as schema from "@kdx/db/schema";
+import { todos } from "@kdx/db/schema";
 
 import type { TProtectedProcedureContext } from "../../../procedures";
 
@@ -11,7 +11,7 @@ interface UpdateOptions {
 
 export const updateHandler = async ({ ctx, input }: UpdateOptions) => {
   await ctx.db
-    .update(schema.todos)
+    .update(todos)
     .set({
       title: input.title,
       assignedToUserId: input.assignedToUserId,
@@ -22,8 +22,8 @@ export const updateHandler = async ({ ctx, input }: UpdateOptions) => {
     })
     .where(
       and(
-        eq(schema.todos.id, input.id),
-        eq(schema.todos.teamId, ctx.session.user.activeTeamId),
+        eq(todos.id, input.id),
+        eq(todos.teamId, ctx.session.user.activeTeamId),
       ),
     );
 };

--- a/packages/api/src/routers/team/appRole/getPermissions.handler.ts
+++ b/packages/api/src/routers/team/appRole/getPermissions.handler.ts
@@ -1,6 +1,6 @@
 import type { TGetPermissionsInputSchema } from "@kdx/validators/trpc/team/appRole";
 import { eq } from "@kdx/db";
-import * as schema from "@kdx/db/schema";
+import { teamAppRoles } from "@kdx/db/schema";
 
 import type { TIsTeamOwnerProcedureContext } from "../../../procedures";
 
@@ -14,9 +14,9 @@ export const getPermissionsHandler = async ({
   input,
 }: GetPermissionsOptions) => {
   const teamAppRolesIdsForActiveTeamId = await ctx.db
-    .select({ id: schema.teamAppRoles.id })
-    .from(schema.teamAppRoles)
-    .where(eq(schema.teamAppRoles.teamId, ctx.session.user.activeTeamId))
+    .select({ id: teamAppRoles.id })
+    .from(teamAppRoles)
+    .where(eq(teamAppRoles.teamId, ctx.session.user.activeTeamId))
     .then((res) => res.map((r) => r.id));
 
   const permissions = await ctx.db.query.appPermissions.findMany({

--- a/packages/api/src/routers/team/appRole/getUsersWithRoles.handler.ts
+++ b/packages/api/src/routers/team/appRole/getUsersWithRoles.handler.ts
@@ -1,6 +1,6 @@
 import type { TGetUsersWithRolesInputSchema } from "@kdx/validators/trpc/team/appRole";
 import { and, eq } from "@kdx/db";
-import * as schema from "@kdx/db/schema";
+import { teamAppRoles, usersToTeams } from "@kdx/db/schema";
 
 import type { TIsTeamOwnerProcedureContext } from "../../../procedures";
 
@@ -18,9 +18,9 @@ export const getUsersWithRolesHandler = async ({
       inArray(
         users.id,
         ctx.db
-          .select({ id: schema.usersToTeams.userId })
-          .from(schema.usersToTeams)
-          .where(eq(schema.usersToTeams.teamId, ctx.session.user.activeTeamId)),
+          .select({ id: usersToTeams.userId })
+          .from(usersToTeams)
+          .where(eq(usersToTeams.teamId, ctx.session.user.activeTeamId)),
       ),
     with: {
       TeamAppRolesToUsers: {
@@ -28,12 +28,12 @@ export const getUsersWithRolesHandler = async ({
           inArray(
             teamAppRolesToUsers.teamAppRoleId,
             ctx.db
-              .select({ id: schema.teamAppRoles.id })
-              .from(schema.teamAppRoles)
+              .select({ id: teamAppRoles.id })
+              .from(teamAppRoles)
               .where(
                 and(
-                  eq(schema.teamAppRoles.teamId, ctx.session.user.activeTeamId),
-                  eq(schema.teamAppRoles.appId, input.appId),
+                  eq(teamAppRoles.teamId, ctx.session.user.activeTeamId),
+                  eq(teamAppRoles.appId, input.appId),
                 ),
               ),
           ),

--- a/packages/api/src/routers/team/appRole/updatePermissionAssociation.handler.ts
+++ b/packages/api/src/routers/team/appRole/updatePermissionAssociation.handler.ts
@@ -1,6 +1,6 @@
 import type { TUpdatePermissionAssociationInputSchema } from "@kdx/validators/trpc/team/appRole";
 import { eq, inArray } from "@kdx/db";
-import * as schema from "@kdx/db/schema";
+import { appPermissionsToTeamAppRoles, teamAppRoles } from "@kdx/db/schema";
 
 import type { TIsTeamOwnerProcedureContext } from "../../../procedures";
 
@@ -15,20 +15,18 @@ export const updatePermissionAssociationHandler = async ({
 }: UpdatePermissionAssociationOptions) => {
   await ctx.db.transaction(async (tx) => {
     await tx
-      .delete(schema.appPermissionsToTeamAppRoles)
+      .delete(appPermissionsToTeamAppRoles)
       .where(
         inArray(
-          schema.appPermissionsToTeamAppRoles.teamAppRoleId,
+          appPermissionsToTeamAppRoles.teamAppRoleId,
           ctx.db
-            .select({ id: schema.teamAppRoles.id })
-            .from(schema.teamAppRoles)
-            .where(
-              eq(schema.teamAppRoles.teamId, ctx.session.user.activeTeamId),
-            ),
+            .select({ id: teamAppRoles.id })
+            .from(teamAppRoles)
+            .where(eq(teamAppRoles.teamId, ctx.session.user.activeTeamId)),
         ),
       );
     if (input.teamAppRoleIds.length > 0)
-      await tx.insert(schema.appPermissionsToTeamAppRoles).values(
+      await tx.insert(appPermissionsToTeamAppRoles).values(
         input.teamAppRoleIds.map((id) => ({
           teamAppRoleId: id,
           appPermissionId: input.permissionId,

--- a/packages/api/src/routers/team/appRole/updateUserAssociation.handler.ts
+++ b/packages/api/src/routers/team/appRole/updateUserAssociation.handler.ts
@@ -1,6 +1,6 @@
 import type { TUpdateUserAssociationInputSchema } from "@kdx/validators/trpc/team/appRole";
 import { eq } from "@kdx/db";
-import * as schema from "@kdx/db/schema";
+import { teamAppRolesToUsers } from "@kdx/db/schema";
 
 import type { TIsTeamOwnerProcedureContext } from "../../../procedures";
 
@@ -15,12 +15,12 @@ export const updateUserAssociationHandler = async ({
 }: UpdateUserAssociationOptions) => {
   await ctx.db.transaction(async (tx) => {
     await tx
-      .delete(schema.teamAppRolesToUsers)
-      .where(eq(schema.teamAppRolesToUsers.userId, input.userId));
+      .delete(teamAppRolesToUsers)
+      .where(eq(teamAppRolesToUsers.userId, input.userId));
 
     if (input.teamAppRoleIds.length)
       // If there are any teamAppRoleIds to connect, insert them after deletion
-      await tx.insert(schema.teamAppRolesToUsers).values(
+      await tx.insert(teamAppRolesToUsers).values(
         input.teamAppRoleIds.map((appRoleId) => ({
           userId: input.userId,
           teamAppRoleId: appRoleId,

--- a/packages/api/src/routers/team/create.handler.ts
+++ b/packages/api/src/routers/team/create.handler.ts
@@ -1,6 +1,6 @@
 import type { TCreateInputSchema } from "@kdx/validators/trpc/team";
 import { nanoid } from "@kdx/db/nanoid";
-import * as schema from "@kdx/db/schema";
+import { teams, usersToTeams } from "@kdx/db/schema";
 
 import type { TProtectedProcedureContext } from "../../procedures";
 
@@ -12,13 +12,13 @@ interface CreateOptions {
 export const createHandler = async ({ ctx, input }: CreateOptions) => {
   const teamId = nanoid();
   await ctx.db.transaction(async (tx) => {
-    const team = await tx.insert(schema.teams).values({
+    const team = await tx.insert(teams).values({
       id: teamId,
       ownerId: ctx.session.user.id,
       name: input.teamName,
     });
     await tx
-      .insert(schema.usersToTeams)
+      .insert(usersToTeams)
       .values({ userId: ctx.session.user.id, teamId });
     return team;
   });

--- a/packages/api/src/routers/team/getAllForLoggedUser.handler.ts
+++ b/packages/api/src/routers/team/getAllForLoggedUser.handler.ts
@@ -1,6 +1,6 @@
 import { eq, sql } from "@kdx/db";
 import { db } from "@kdx/db/client";
-import * as schema from "@kdx/db/schema";
+import { teams, usersToTeams } from "@kdx/db/schema";
 
 import type { TProtectedProcedureContext } from "../../procedures";
 
@@ -9,13 +9,10 @@ interface GetAllForLoggedUserOptions {
 }
 
 const prepared = db
-  .select({ teams: schema.teams })
-  .from(schema.teams)
-  .where(eq(schema.usersToTeams.userId, sql.placeholder("userId")))
-  .innerJoin(
-    schema.usersToTeams,
-    eq(schema.usersToTeams.teamId, schema.teams.id),
-  )
+  .select({ teams: teams })
+  .from(teams)
+  .where(eq(usersToTeams.userId, sql.placeholder("userId")))
+  .innerJoin(usersToTeams, eq(usersToTeams.teamId, teams.id))
   .prepare();
 
 export const getAllForLoggedUserHandler = async ({

--- a/packages/api/src/routers/team/getAllUsers.handler.ts
+++ b/packages/api/src/routers/team/getAllUsers.handler.ts
@@ -1,5 +1,5 @@
 import { eq } from "@kdx/db";
-import * as schema from "@kdx/db/schema";
+import { users, usersToTeams } from "@kdx/db/schema";
 
 import type { TProtectedProcedureContext } from "../../procedures";
 
@@ -10,15 +10,12 @@ interface GetAllUsersOptions {
 export const getAllUsersHandler = async ({ ctx }: GetAllUsersOptions) => {
   return await ctx.db
     .select({
-      id: schema.users.id,
-      email: schema.users.email,
-      name: schema.users.name,
-      image: schema.users.image,
+      id: users.id,
+      email: users.email,
+      name: users.name,
+      image: users.image,
     })
-    .from(schema.users)
-    .where(eq(schema.usersToTeams.teamId, ctx.session.user.activeTeamId))
-    .innerJoin(
-      schema.usersToTeams,
-      eq(schema.usersToTeams.userId, schema.users.id),
-    );
+    .from(users)
+    .where(eq(usersToTeams.teamId, ctx.session.user.activeTeamId))
+    .innerJoin(usersToTeams, eq(usersToTeams.userId, users.id));
 };

--- a/packages/api/src/routers/team/invitation/decline.handler.ts
+++ b/packages/api/src/routers/team/invitation/decline.handler.ts
@@ -2,7 +2,7 @@ import { TRPCError } from "@trpc/server";
 
 import type { TDeclineInputSchema } from "@kdx/validators/trpc/team/invitation";
 import { eq } from "@kdx/db";
-import * as schema from "@kdx/db/schema";
+import { invitations } from "@kdx/db/schema";
 
 import type { TProtectedProcedureContext } from "../../../procedures";
 
@@ -28,6 +28,6 @@ export const declineHandler = async ({ ctx, input }: DeclineOptions) => {
   }
 
   await ctx.db
-    .delete(schema.invitations)
-    .where(eq(schema.invitations.id, input.invitationId));
+    .delete(invitations)
+    .where(eq(invitations.id, input.invitationId));
 };

--- a/packages/api/src/routers/team/invitation/delete.handler.ts
+++ b/packages/api/src/routers/team/invitation/delete.handler.ts
@@ -2,7 +2,7 @@ import { TRPCError } from "@trpc/server";
 
 import type { TDeleteInputSchema } from "@kdx/validators/trpc/team/invitation";
 import { and, eq } from "@kdx/db";
-import * as schema from "@kdx/db/schema";
+import { invitations } from "@kdx/db/schema";
 
 import type { TProtectedProcedureContext } from "../../../procedures";
 
@@ -27,6 +27,6 @@ export const deleteHandler = async ({ ctx, input }: DeleteOptions) => {
     });
 
   await ctx.db
-    .delete(schema.invitations)
-    .where(eq(schema.invitations.id, input.invitationId));
+    .delete(invitations)
+    .where(eq(invitations.id, input.invitationId));
 };

--- a/packages/api/src/routers/team/invitation/invite.handler.ts
+++ b/packages/api/src/routers/team/invitation/invite.handler.ts
@@ -3,7 +3,7 @@ import { TRPCError } from "@trpc/server";
 
 import type { TInviteInputSchema } from "@kdx/validators/trpc/team/invitation";
 import { nanoid } from "@kdx/db/nanoid";
-import * as schema from "@kdx/db/schema";
+import { invitations } from "@kdx/db/schema";
 import TeamInvite from "@kdx/react-email/team-invite";
 import {
   getBaseUrl,
@@ -68,18 +68,18 @@ export const inviteHandler = async ({ ctx, input }: InviteOptions) => {
       code: "CONFLICT",
     });
 
-  const invitations = input.to.map(
+  const _invitations = input.to.map(
     (email) =>
       ({
         id: nanoid(),
         teamId: team.id,
         email,
         invitedById: ctx.session.user.id,
-      }) satisfies typeof schema.invitations.$inferInsert,
+      }) satisfies typeof invitations.$inferInsert,
   );
 
   const results = await Promise.allSettled(
-    invitations.map(async (invite) => {
+    _invitations.map(async (invite) => {
       await resend.emails.send({
         from: kodixNotificationFromEmail,
         to: invite.email,
@@ -100,13 +100,13 @@ export const inviteHandler = async ({ ctx, input }: InviteOptions) => {
   const { successes } = getSuccessesAndErrors(results);
 
   if (successes.length)
-    await ctx.db.insert(schema.invitations).values(
+    await ctx.db.insert(invitations).values(
       successes.map((success) => {
-        return invitations.find((x) => x.id === success.value.id)!;
+        return _invitations.find((x) => x.id === success.value.id)!;
       }),
     );
 
-  const failedInvites = invitations.filter(
+  const failedInvites = _invitations.filter(
     (invite) => !successes.find((x) => x.value.id === invite.id),
   );
   return {

--- a/packages/api/src/routers/team/removeUser.handler.ts
+++ b/packages/api/src/routers/team/removeUser.handler.ts
@@ -3,7 +3,7 @@ import { TRPCError } from "@trpc/server";
 import type { TRemoveUserSchema } from "@kdx/validators/trpc/team";
 import { and, eq, not } from "@kdx/db";
 import { nanoid } from "@kdx/db/nanoid";
-import * as schema from "@kdx/db/schema";
+import { teams, users, usersToTeams } from "@kdx/db/schema";
 
 import type { TProtectedProcedureContext } from "../../procedures";
 
@@ -56,16 +56,13 @@ export const removeUserHandler = async ({ ctx, input }: RemoveUserOptions) => {
 
   //TODO: Implement role based access control
   let otherTeam = await ctx.db
-    .select({ id: schema.teams.id })
-    .from(schema.teams)
-    .innerJoin(
-      schema.usersToTeams,
-      eq(schema.teams.id, schema.usersToTeams.teamId),
-    )
+    .select({ id: teams.id })
+    .from(teams)
+    .innerJoin(usersToTeams, eq(teams.id, usersToTeams.teamId))
     .where(
       and(
-        not(eq(schema.teams.id, ctx.session.user.activeTeamId)),
-        eq(schema.usersToTeams.userId, input.userId),
+        not(eq(teams.id, ctx.session.user.activeTeamId)),
+        eq(usersToTeams.userId, input.userId),
       ),
     )
     .then((res) => res[0]);
@@ -75,15 +72,15 @@ export const removeUserHandler = async ({ ctx, input }: RemoveUserOptions) => {
     if (!otherTeam) {
       //Create a new team for the user and move them to it
       const newTeamId = nanoid();
-      await tx.insert(schema.teams).values({
+      await tx.insert(teams).values({
         id: newTeamId,
         ownerId: input.userId,
         name: "Personal Team",
       });
       await tx
-        .insert(schema.usersToTeams)
+        .insert(usersToTeams)
         .values({ userId: input.userId, teamId: newTeamId });
-      await tx.update(schema.users).set({
+      await tx.update(users).set({
         activeTeamId: newTeamId,
       });
 
@@ -92,19 +89,19 @@ export const removeUserHandler = async ({ ctx, input }: RemoveUserOptions) => {
 
     //Move the user to the other team
     await tx
-      .update(schema.users)
+      .update(users)
       .set({
         activeTeamId: otherTeam.id,
       })
-      .where(eq(schema.users.id, input.userId));
+      .where(eq(users.id, input.userId));
 
     //Remove the user from the team
     await tx
-      .delete(schema.usersToTeams)
+      .delete(usersToTeams)
       .where(
         and(
-          eq(schema.usersToTeams.userId, input.userId),
-          eq(schema.usersToTeams.teamId, ctx.session.user.activeTeamId),
+          eq(usersToTeams.userId, input.userId),
+          eq(usersToTeams.teamId, ctx.session.user.activeTeamId),
         ),
       );
   });

--- a/packages/api/src/routers/team/update.handler.ts
+++ b/packages/api/src/routers/team/update.handler.ts
@@ -1,6 +1,6 @@
 import type { TUpdateInputSchema } from "@kdx/validators/trpc/team";
 import { eq } from "@kdx/db";
-import * as schema from "@kdx/db/schema";
+import { teams } from "@kdx/db/schema";
 
 import type { TProtectedProcedureContext } from "../../procedures";
 
@@ -11,10 +11,10 @@ interface CreateHandler {
 
 export const updateHandler = async ({ ctx, input }: CreateHandler) => {
   const team = await ctx.db
-    .update(schema.teams)
+    .update(teams)
     .set({
       name: input.teamName,
     })
-    .where(eq(schema.teams.id, input.teamId));
+    .where(eq(teams.id, input.teamId));
   return team;
 };

--- a/packages/api/src/routers/user/changeName.handler.ts
+++ b/packages/api/src/routers/user/changeName.handler.ts
@@ -1,6 +1,6 @@
 import type { TChangeNameInputSchema } from "@kdx/validators/trpc/user";
 import { eq } from "@kdx/db";
-import * as schema from "@kdx/db/schema";
+import { users } from "@kdx/db/schema";
 
 import type { TProtectedProcedureContext } from "../../procedures";
 
@@ -11,7 +11,7 @@ interface ChangeNameOptions {
 
 export const changeNameHandler = async ({ ctx, input }: ChangeNameOptions) => {
   return await ctx.db
-    .update(schema.users)
+    .update(users)
     .set({ name: input.name })
-    .where(eq(schema.users.id, ctx.session.user.id));
+    .where(eq(users.id, ctx.session.user.id));
 };

--- a/packages/api/src/routers/user/changePassword.handler.ts
+++ b/packages/api/src/routers/user/changePassword.handler.ts
@@ -3,7 +3,7 @@ import { TRPCError } from "@trpc/server";
 
 import type { TChangePasswordInputSchema } from "@kdx/validators/trpc/user";
 import { eq } from "@kdx/db";
-import * as schema from "@kdx/db/schema";
+import { resetPasswordTokens, users } from "@kdx/db/schema";
 
 import type { TPublicProcedureContext } from "../../procedures";
 import { argon2Config } from "./utils";
@@ -19,7 +19,7 @@ export const changePasswordHandler = async ({
 }: ChangePasswordOptions) => {
   const existingToken = await ctx.db.query.resetPasswordTokens.findFirst({
     where: (resetPasswordTokens, { eq }) =>
-      eq(schema.resetPasswordTokens.token, input.token),
+      eq(resetPasswordTokens.token, input.token),
     columns: {
       userId: true,
     },
@@ -33,13 +33,13 @@ export const changePasswordHandler = async ({
   const hashed = await hash(input.password, argon2Config);
   await ctx.db.transaction(async (tx) => {
     await tx
-      .delete(schema.resetPasswordTokens)
-      .where(eq(schema.resetPasswordTokens.token, input.token));
+      .delete(resetPasswordTokens)
+      .where(eq(resetPasswordTokens.token, input.token));
     await tx
-      .update(schema.users)
+      .update(users)
       .set({
         passwordHash: hashed,
       })
-      .where(eq(schema.users.id, existingToken.userId));
+      .where(eq(users.id, existingToken.userId));
   });
 };

--- a/packages/api/src/routers/user/deleteNotifications.handler.ts
+++ b/packages/api/src/routers/user/deleteNotifications.handler.ts
@@ -1,6 +1,6 @@
 import type { TDeleteNotificationsInputSchema } from "@kdx/validators/trpc/user";
 import { and, eq, inArray } from "@kdx/db";
-import * as schema from "@kdx/db/schema";
+import { notifications } from "@kdx/db/schema";
 
 import type { TProtectedProcedureContext } from "../../procedures";
 
@@ -14,11 +14,11 @@ export const deleteNotificationsHandler = async ({
   input,
 }: DeleteNotificationsOptions) => {
   await ctx.db
-    .delete(schema.notifications)
+    .delete(notifications)
     .where(
       and(
-        eq(schema.notifications.sentToUserId, ctx.session.user.id),
-        inArray(schema.notifications.id, input.ids),
+        eq(notifications.sentToUserId, ctx.session.user.id),
+        inArray(notifications.id, input.ids),
       ),
     );
 };

--- a/packages/api/src/routers/user/sendResetPasswordEmail.ts
+++ b/packages/api/src/routers/user/sendResetPasswordEmail.ts
@@ -3,7 +3,7 @@ import { TRPCError } from "@trpc/server";
 import type { TSendResetPasswordEmailInputSchema } from "@kdx/validators/trpc/user";
 import { eq } from "@kdx/db";
 import { nanoid } from "@kdx/db/nanoid";
-import * as schema from "@kdx/db/schema";
+import { resetPasswordTokens } from "@kdx/db/schema";
 import ResetPassword from "@kdx/react-email/reset-password";
 import { kodixNotificationFromEmail } from "@kdx/shared";
 
@@ -33,10 +33,10 @@ export const sendResetPasswordEmail = async ({
   const tokenExpiresAt = new Date(Date.now() + 1000 * 60 * 5); // 5 minutes
 
   await ctx.db
-    .delete(schema.resetPasswordTokens)
-    .where(eq(schema.resetPasswordTokens.userId, user.id));
+    .delete(resetPasswordTokens)
+    .where(eq(resetPasswordTokens.userId, user.id));
   const token = nanoid();
-  await ctx.db.insert(schema.resetPasswordTokens).values({
+  await ctx.db.insert(resetPasswordTokens).values({
     userId: user.id,
     token,
     tokenExpiresAt,

--- a/packages/api/src/routers/user/signupWithPassword.handler.ts
+++ b/packages/api/src/routers/user/signupWithPassword.handler.ts
@@ -8,7 +8,7 @@ import { createUser } from "@kdx/auth/db";
 import { eq } from "@kdx/db";
 import { db } from "@kdx/db/client";
 import { nanoid } from "@kdx/db/nanoid";
-import * as schema from "@kdx/db/schema";
+import { users } from "@kdx/db/schema";
 
 import type { TPublicProcedureContext } from "../../procedures";
 import { argon2Config } from "./utils";
@@ -24,10 +24,10 @@ export const signupWithPasswordHandler = async ({
 }: SignupWithPasswordOptions) => {
   const registered = await ctx.db
     .select({
-      id: schema.users.id,
+      id: users.id,
     })
-    .from(schema.users)
-    .where(eq(schema.users.email, input.email))
+    .from(users)
+    .where(eq(users.email, input.email))
     .then((res) => !!res[0]);
 
   if (registered)

--- a/packages/api/src/routers/user/switchActiveTeam.handler.ts
+++ b/packages/api/src/routers/user/switchActiveTeam.handler.ts
@@ -1,6 +1,6 @@
 import type { TSwitchActiveTeamInputSchema } from "@kdx/validators/trpc/user";
 import { eq } from "@kdx/db";
-import * as schema from "@kdx/db/schema";
+import { users } from "@kdx/db/schema";
 
 import type { TProtectedProcedureContext } from "../../procedures";
 
@@ -13,8 +13,8 @@ export const switchActiveTeamHandler = async ({
   ctx,
   input,
 }: SwitchActiveTeamOptions) => {
-  await ctx.db.update(schema.users).set({ activeTeamId: input.teamId }).where(
-    eq(schema.users.id, ctx.session.user.id),
+  await ctx.db.update(users).set({ activeTeamId: input.teamId }).where(
+    eq(users.id, ctx.session.user.id),
     //TODO: Make sure they are part of the team!!
   );
 };

--- a/packages/auth/src/db.ts
+++ b/packages/auth/src/db.ts
@@ -3,7 +3,7 @@
 
 import type { Drizzle, DrizzleTransaction } from "@kdx/db/client";
 import { eq } from "@kdx/db";
-import * as schema from "@kdx/db/schema";
+import { invitations, teams, users, usersToTeams } from "@kdx/db/schema";
 
 export async function createUser({
   invite,
@@ -24,7 +24,7 @@ export async function createUser({
   passwordHash?: string;
   tx: DrizzleTransaction;
 }) {
-  await tx.insert(schema.users).values({
+  await tx.insert(users).values({
     id: userId,
     name: name,
     activeTeamId: teamId,
@@ -35,13 +35,13 @@ export async function createUser({
   if (invite) {
     await acceptInvite({ invite, userId, email, db: tx });
   } else {
-    await tx.insert(schema.teams).values({
+    await tx.insert(teams).values({
       id: teamId,
       ownerId: userId,
       name: `Personal Team`,
     });
 
-    await tx.insert(schema.usersToTeams).values({
+    await tx.insert(usersToTeams).values({
       userId: userId,
       teamId: teamId,
     });
@@ -74,14 +74,14 @@ export async function acceptInvite({
   if (!invitation) throw new Error("No invitation found");
 
   await db
-    .update(schema.users)
+    .update(users)
     .set({
       activeTeamId: invitation.Team.id,
     })
-    .where(eq(schema.users.id, userId));
-  await db.insert(schema.usersToTeams).values({
+    .where(eq(users.id, userId));
+  await db.insert(usersToTeams).values({
     userId: userId,
     teamId: invitation.Team.id,
   });
-  await db.delete(schema.invitations).where(eq(schema.invitations.id, invite));
+  await db.delete(invitations).where(eq(invitations.id, invite));
 }

--- a/packages/auth/src/lucia-custom-adapter.ts
+++ b/packages/auth/src/lucia-custom-adapter.ts
@@ -5,7 +5,7 @@ import type { Adapter, DatabaseSession, DatabaseUser } from "lucia";
 import type { Drizzle } from "@kdx/db/client";
 import { eq, lte } from "@kdx/db";
 import { db } from "@kdx/db/client";
-import * as schema from "@kdx/db/schema";
+import { sessions, teams, users } from "@kdx/db/schema";
 
 class KodixAdapter implements Adapter {
   db;
@@ -14,9 +14,9 @@ class KodixAdapter implements Adapter {
   teamTable;
   constructor(
     db: Drizzle,
-    sessionTable: typeof schema.sessions,
-    userTable: typeof schema.users,
-    teamTable: typeof schema.teams,
+    sessionTable: typeof sessions,
+    userTable: typeof users,
+    teamTable: typeof teams,
   ) {
     this.db = db;
     this.sessionTable = sessionTable;
@@ -111,9 +111,4 @@ function transformIntoDatabaseUser(raw: any, activeTeamName: string) {
   };
 }
 
-export const adapter = new KodixAdapter(
-  db,
-  schema.sessions,
-  schema.users,
-  schema.teams,
-);
+export const adapter = new KodixAdapter(db, sessions, users, teams);

--- a/packages/auth/src/providers/utils/createOrGetExistingUserForUnlinkedProviderAccount.ts
+++ b/packages/auth/src/providers/utils/createOrGetExistingUserForUnlinkedProviderAccount.ts
@@ -2,7 +2,7 @@ import { cookies } from "next/headers";
 
 import { db } from "@kdx/db/client";
 import { nanoid } from "@kdx/db/nanoid";
-import * as schema from "@kdx/db/schema";
+import { accounts } from "@kdx/db/schema";
 
 import { createUser } from "../../db";
 
@@ -49,7 +49,7 @@ export default async function createOrGetExistingUserForUnlinkedProviderAccount(
       userId = existingUser.id;
     }
 
-    await tx.insert(schema.accounts).values({
+    await tx.insert(accounts).values({
       providerId: providerId,
       providerUserId: providerUserId,
       userId,

--- a/packages/db/src/scripts/seed/index.ts
+++ b/packages/db/src/scripts/seed/index.ts
@@ -8,10 +8,10 @@ import {
 
 import { sql } from "../..";
 import { db } from "../../client";
-import * as schema from "../../schema";
+import { appPermissions, apps, devPartners } from "../../schema";
 import { appRoles_defaultTree } from "./appRolesDefault_tree";
 
-const devPartners: (typeof schema.devPartners.$inferInsert)[] = [
+const _devPartners: (typeof devPartners.$inferInsert)[] = [
   {
     id: kdxPartnerId,
     name: "Kodix",
@@ -19,7 +19,7 @@ const devPartners: (typeof schema.devPartners.$inferInsert)[] = [
   },
 ];
 
-export const apps: (typeof schema.apps.$inferInsert)[] = [
+export const _apps: (typeof apps.$inferInsert)[] = [
   {
     id: todoAppId, //As const so it can be used as a type
     devPartnerId: kdxPartnerId,
@@ -39,8 +39,7 @@ async function main() {
   validateSeedInput();
 
   await db.transaction(async (tx) => {
-    const toInsertAppPermissions: (typeof schema.appPermissions.$inferInsert)[] =
-      [];
+    const toInsertAppPermissions: (typeof appPermissions.$inferInsert)[] = [];
 
     for (const [appId, { appPermissions }] of Object.entries(
       appRoles_defaultTree,
@@ -57,19 +56,19 @@ async function main() {
     }
 
     await tx
-      .insert(schema.devPartners)
-      .values(devPartners)
+      .insert(devPartners)
+      .values(_devPartners)
       .onDuplicateKeyUpdate({
-        set: allSetValues(devPartners),
+        set: allSetValues(_devPartners),
       });
     await tx
-      .insert(schema.apps)
-      .values(apps)
+      .insert(apps)
+      .values(_apps)
       .onDuplicateKeyUpdate({
-        set: allSetValues(apps),
+        set: allSetValues(_apps),
       });
     await tx
-      .insert(schema.appPermissions)
+      .insert(appPermissions)
       .values(toInsertAppPermissions)
       .onDuplicateKeyUpdate({
         set: allSetValues(toInsertAppPermissions),


### PR DESCRIPTION
This pull request updates the import statements for the schema files. The import statements have been changed to import specific tables from the schema files instead of importing the entire schema module. This improves code readability and reduces the risk of importing unnecessary code.