### PR TITLE
Rename `session` from AuthResponse to `auth`

### DIFF
--- a/apps/kdx/src/app/[locale]/(authed)/account/general/page.tsx
+++ b/apps/kdx/src/app/[locale]/(authed)/account/general/page.tsx
@@ -12,7 +12,9 @@ import { EditUserTeamsTable } from "./_components/edit-users-teams-card/edit-use
 
 export default async function GeneralAccountSettings() {
   const { user } = await auth();
+
   if (!user) return redirect("/");
+
   const t = await getTranslations();
 
   return (

--- a/apps/kdx/src/app/api/trpc/[trpc]/route.ts
+++ b/apps/kdx/src/app/api/trpc/[trpc]/route.ts
@@ -8,7 +8,7 @@ import { OPTIONS, setCorsHeaders } from "../../_enableCors";
 export const runtime = "nodejs";
 
 const handler = async (req: Request) => {
-  const currentUser = await auth();
+  const authResponse = await auth();
 
   const response = await fetchRequestHandler({
     endpoint: "/api/trpc",
@@ -16,7 +16,7 @@ const handler = async (req: Request) => {
     req,
     createContext: () =>
       createTRPCContext({
-        session: currentUser,
+        auth: authResponse,
         headers: req.headers,
       }),
     onError({ error, path }) {

--- a/apps/kdx/src/trpc/server.ts
+++ b/apps/kdx/src/trpc/server.ts
@@ -13,7 +13,7 @@ const createContext = cache(async () => {
   heads.set("x-trpc-source", "rsc");
 
   return createTRPCContext({
-    session: await auth(),
+    auth: await auth(),
     headers: heads,
   });
 });

--- a/packages/api/src/trpc/middlewares.ts
+++ b/packages/api/src/trpc/middlewares.ts
@@ -47,8 +47,8 @@ export const appPermissionMiddleware = (permissionId: AppPermissionId) =>
     ctx: TProtectedProcedureContext;
   }>().create(async ({ ctx, next }) => {
     let foundPermission = await getUpstashCache("permissions", {
-      userId: ctx.session.user.id,
-      teamId: ctx.session.user.activeTeamId,
+      userId: ctx.auth.user.id,
+      teamId: ctx.auth.user.activeTeamId,
       permissionId,
     });
 
@@ -66,8 +66,8 @@ export const appPermissionMiddleware = (permissionId: AppPermissionId) =>
         )
         .where(
           and(
-            eq(teamAppRolesToUsers.userId, ctx.session.user.id),
-            eq(teamAppRoles.teamId, ctx.session.user.activeTeamId),
+            eq(teamAppRolesToUsers.userId, ctx.auth.user.id),
+            eq(teamAppRoles.teamId, ctx.auth.user.activeTeamId),
             eq(appPermissionsToTeamAppRoles.appPermissionId, permissionId),
           ),
         )
@@ -75,8 +75,8 @@ export const appPermissionMiddleware = (permissionId: AppPermissionId) =>
 
       await setUpstashCache("permissions", {
         variableKeys: {
-          userId: ctx.session.user.id,
-          teamId: ctx.session.user.activeTeamId,
+          userId: ctx.auth.user.id,
+          teamId: ctx.auth.user.activeTeamId,
           permissionId,
         },
         value: permission,

--- a/packages/api/src/trpc/procedures.ts
+++ b/packages/api/src/trpc/procedures.ts
@@ -27,18 +27,19 @@ export type TPublicProcedureContext = inferProcedureBuilderResolverOptions<
  * Protected (authenticated) procedure
  *
  * If you want a query or mutation to ONLY be accessible to logged in users, use this. It verifies
- * the session is valid and guarantees `ctx.session.user` is not null.
+ * the session is valid and guarantees `ctx.auth.user` is not null.
  *
  * @see https://trpc.io/docs/procedures
  */
 export const protectedProcedure = publicProcedure.use(({ ctx, next }) => {
-  if (!ctx.session?.user) {
+  if (!ctx.auth.user) {
     throw new TRPCError({ code: "UNAUTHORIZED" });
   }
   return next({
     ctx: {
-      // infers the `session` as non-nullable
-      session: { ...ctx.session, user: ctx.session.user },
+      ...ctx,
+      // infers the `user` and `session` as non-nullable
+      auth: ctx.auth,
     },
   });
 });
@@ -49,7 +50,7 @@ export type TProtectedProcedureContext = inferProcedureBuilderResolverOptions<
 export const isTeamOwnerProcedure = protectedProcedure.use(
   async ({ ctx, next }) => {
     const team = await ctx.db.query.teams.findFirst({
-      where: eq(teams.id, ctx.session.user.activeTeamId),
+      where: eq(teams.id, ctx.auth.user.activeTeamId),
       columns: {
         id: true,
         ownerId: true,
@@ -63,7 +64,7 @@ export const isTeamOwnerProcedure = protectedProcedure.use(
         code: "NOT_FOUND",
       });
 
-    if (team.ownerId !== ctx.session.user.id)
+    if (team.ownerId !== ctx.auth.user.id)
       throw new TRPCError({
         message: t("api.Only the team owner can perform this action"),
         code: "FORBIDDEN",

--- a/packages/api/src/trpc/routers/app/calendar/cancel.handler.ts
+++ b/packages/api/src/trpc/routers/app/calendar/cancel.handler.ts
@@ -60,7 +60,7 @@ export const cancelHandler = async ({ ctx, input }: CancelOptions) => {
         const allEventMastersIdsForThisTeamQuery = ctx.db
           .select({ id: eventMasters.id })
           .from(eventMasters)
-          .where(eq(eventMasters.teamId, ctx.session.user.activeTeamId));
+          .where(eq(eventMasters.teamId, ctx.auth.user.activeTeamId));
 
         await tx
           .delete(eventExceptions)

--- a/packages/api/src/trpc/routers/app/calendar/create.handler.ts
+++ b/packages/api/src/trpc/routers/app/calendar/create.handler.ts
@@ -22,7 +22,7 @@ export const createHandler = async ({ ctx, input }: CreateOptions) => {
       count: input.count,
       byweekday: input.weekdays,
     }).toString(),
-    teamId: ctx.session.user.activeTeamId,
+    teamId: ctx.auth.user.activeTeamId,
     dateStart: input.from,
     dateUntil: input.until,
     type: input.type,

--- a/packages/api/src/trpc/routers/app/calendar/edit.handler.ts
+++ b/packages/api/src/trpc/routers/app/calendar/edit.handler.ts
@@ -21,7 +21,7 @@ export const editHandler = async ({ ctx, input }: EditOptions) => {
   const allEventMastersIdsForThisTeamQuery = ctx.db
     .select({ id: eventMasters.id })
     .from(eventMasters)
-    .where(eq(eventMasters.teamId, ctx.session.user.activeTeamId));
+    .where(eq(eventMasters.teamId, ctx.auth.user.activeTeamId));
 
   if (input.editDefinition === "single") {
     //* Havemos description, title, from e selectedTimestamp.
@@ -61,7 +61,7 @@ export const editHandler = async ({ ctx, input }: EditOptions) => {
       where: (eventMasters, { and, eq }) =>
         and(
           eq(eventMasters.id, input.eventMasterId),
-          eq(eventMasters.teamId, ctx.session.user.activeTeamId),
+          eq(eventMasters.teamId, ctx.auth.user.activeTeamId),
         ),
       columns: {
         id: true,
@@ -149,7 +149,7 @@ export const editHandler = async ({ ctx, input }: EditOptions) => {
         where: (eventMasters, { and, eq }) =>
           and(
             eq(eventMasters.id, input.eventMasterId),
-            eq(eventMasters.teamId, ctx.session.user.activeTeamId),
+            eq(eventMasters.teamId, ctx.auth.user.activeTeamId),
           ),
         columns: {
           rule: true,
@@ -203,7 +203,7 @@ export const editHandler = async ({ ctx, input }: EditOptions) => {
           .where(
             and(
               eq(eventMasters.id, input.eventMasterId),
-              eq(eventMasters.teamId, ctx.session.user.activeTeamId),
+              eq(eventMasters.teamId, ctx.auth.user.activeTeamId),
             ),
           );
         if (shouldDeleteFutureExceptions) return; //* We don't need to update the exceptions if we are deleting them already.
@@ -236,14 +236,14 @@ export const editHandler = async ({ ctx, input }: EditOptions) => {
         .where(
           and(
             eq(eventMasters.id, input.eventMasterId),
-            eq(eventMasters.teamId, ctx.session.user.activeTeamId),
+            eq(eventMasters.teamId, ctx.auth.user.activeTeamId),
           ),
         );
 
       const newMasterId = nanoid();
       await tx.insert(eventMasters).values({
         id: newMasterId,
-        teamId: ctx.session.user.activeTeamId,
+        teamId: ctx.auth.user.activeTeamId,
         dateStart: input.from ?? input.selectedTimestamp,
         dateUntil: input.until ?? oldRule.options.until ?? undefined,
         rule: new RRule({
@@ -309,7 +309,7 @@ export const editHandler = async ({ ctx, input }: EditOptions) => {
             where: (eventMasters, { and, eq }) =>
               and(
                 eq(eventMasters.id, input.eventMasterId),
-                eq(eventMasters.teamId, ctx.session.user.activeTeamId),
+                eq(eventMasters.teamId, ctx.auth.user.activeTeamId),
               ),
             columns: {
               rule: true,
@@ -357,7 +357,7 @@ export const editHandler = async ({ ctx, input }: EditOptions) => {
         .where(
           and(
             eq(eventMasters.id, input.eventMasterId),
-            eq(eventMasters.teamId, ctx.session.user.activeTeamId),
+            eq(eventMasters.teamId, ctx.auth.user.activeTeamId),
           ),
         );
 

--- a/packages/api/src/trpc/routers/app/calendar/getAll.handler.ts
+++ b/packages/api/src/trpc/routers/app/calendar/getAll.handler.ts
@@ -15,7 +15,7 @@ export const getAllHandler = async ({
   const calendarTasks = await getCalendarTasks({
     dateStart: input.dateStart,
     dateEnd: input.dateEnd,
-    teamIds: [ctx.session.user.activeTeamId],
+    teamIds: [ctx.auth.user.activeTeamId],
     ctx,
   });
   return calendarTasks;

--- a/packages/api/src/trpc/routers/app/calendar/nuke.handler.ts
+++ b/packages/api/src/trpc/routers/app/calendar/nuke.handler.ts
@@ -11,7 +11,7 @@ interface NukeOptions {
 }
 
 export const nukeHandler = async ({ ctx }: NukeOptions) => {
-  if (!authorizedEmails.includes(ctx.session.user.email))
+  if (!authorizedEmails.includes(ctx.auth.user.email))
     throw new TRPCError({
       code: "UNAUTHORIZED",
       message: "You are not authorized to do this",
@@ -19,5 +19,5 @@ export const nukeHandler = async ({ ctx }: NukeOptions) => {
 
   await ctx.db
     .delete(eventMasters)
-    .where(eq(eventMasters.teamId, ctx.session.user.activeTeamId));
+    .where(eq(eventMasters.teamId, ctx.auth.user.activeTeamId));
 };

--- a/packages/api/src/trpc/routers/app/getConfig.handler.ts
+++ b/packages/api/src/trpc/routers/app/getConfig.handler.ts
@@ -15,7 +15,7 @@ interface GetConfigOptions {
 export const getConfigHandler = async ({ ctx, input }: GetConfigOptions) => {
   const [teamConfig] = await getConfigs({
     appId: input.appId,
-    teamIds: [ctx.session.user.activeTeamId],
+    teamIds: [ctx.auth.user.activeTeamId],
     ctx,
   });
 

--- a/packages/api/src/trpc/routers/app/getUserAppTeamConfig.handler.ts
+++ b/packages/api/src/trpc/routers/app/getUserAppTeamConfig.handler.ts
@@ -16,8 +16,8 @@ export const getUserAppTeamConfigHandler = async ({
 }: GetUserAppTeamConfigOptions) => {
   const [userAppTeamConfig] = await getUsersAppTeamConfigs({
     ctx,
-    userIds: [ctx.session.user.id],
-    teamIds: [ctx.session.user.activeTeamId],
+    userIds: [ctx.auth.user.id],
+    teamIds: [ctx.auth.user.activeTeamId],
     appId: input.appId,
   });
 

--- a/packages/api/src/trpc/routers/app/kodixCare/createCareTask.handler.ts
+++ b/packages/api/src/trpc/routers/app/kodixCare/createCareTask.handler.ts
@@ -26,7 +26,7 @@ export const createCareTaskHandler = async ({
   }
 
   const currentUserIsCaregiver =
-    currentCareShift.Caregiver.id === ctx.session.user.id;
+    currentCareShift.Caregiver.id === ctx.auth.user.id;
   if (!currentUserIsCaregiver) {
     throw new TRPCError({
       code: "FORBIDDEN",
@@ -37,6 +37,6 @@ export const createCareTaskHandler = async ({
   await ctx.db.insert(careTasks).values({
     ...input,
     careShiftId: currentCareShift.id,
-    teamId: ctx.session.user.activeTeamId,
+    teamId: ctx.auth.user.activeTeamId,
   });
 };

--- a/packages/api/src/trpc/routers/app/kodixCare/doCheckoutForShift.handler.ts
+++ b/packages/api/src/trpc/routers/app/kodixCare/doCheckoutForShift.handler.ts
@@ -26,7 +26,7 @@ export const doCheckoutForShiftHandler = async ({
       message: t("api.No current shift found"),
     });
   }
-  if (currentShift.Caregiver.id !== ctx.session.user.id)
+  if (currentShift.Caregiver.id !== ctx.auth.user.id)
     throw new TRPCError({
       code: "FORBIDDEN",
       message: t("api.You are not the caregiver for this shift"),

--- a/packages/api/src/trpc/routers/app/kodixCare/getCareTasks.handler.ts
+++ b/packages/api/src/trpc/routers/app/kodixCare/getCareTasks.handler.ts
@@ -16,7 +16,7 @@ export const getCareTasksHandler = async ({
     ctx,
     dateStart: input.dateStart,
     dateEnd: input.dateEnd,
-    teamIds: [ctx.session.user.activeTeamId],
+    teamIds: [ctx.auth.user.activeTeamId],
   });
 
   return careTasks;

--- a/packages/api/src/trpc/routers/app/kodixCare/getCurrentShift.handler.ts
+++ b/packages/api/src/trpc/routers/app/kodixCare/getCurrentShift.handler.ts
@@ -11,7 +11,7 @@ export const getCurrentShiftHandler = async ({
     orderBy: (careShift, { desc }) => desc(careShift.checkIn),
     where: (careShift, { eq, and, isNull }) =>
       and(
-        eq(careShift.teamId, ctx.session.user.activeTeamId),
+        eq(careShift.teamId, ctx.auth.user.activeTeamId),
         isNull(careShift.shiftEndedAt),
       ),
     with: {

--- a/packages/api/src/trpc/routers/app/kodixCare/saveCareTask.handler.ts
+++ b/packages/api/src/trpc/routers/app/kodixCare/saveCareTask.handler.ts
@@ -26,7 +26,7 @@ export const saveCareTaskHandler = async ({
       message: "No current shift found",
     });
 
-  if (currentShift.Caregiver.id !== ctx.session.user.id)
+  if (currentShift.Caregiver.id !== ctx.auth.user.id)
     throw new TRPCError({
       code: "FORBIDDEN",
       message: t("api.You cannot edit a task from another caregivers shift"),

--- a/packages/api/src/trpc/routers/app/kodixCare/utils/index.ts
+++ b/packages/api/src/trpc/routers/app/kodixCare/utils/index.ts
@@ -33,7 +33,7 @@ export async function cloneCalendarTasksToCareTasks({
     await ctx.db.insert(careTasks).values(
       calendarTasks.map((calendarTask) => ({
         careShiftId: careShiftId,
-        teamId: ctx.session.user.activeTeamId,
+        teamId: ctx.auth.user.activeTeamId,
         title: calendarTask.title,
         description: calendarTask.description,
         date: calendarTask.date,

--- a/packages/api/src/trpc/routers/app/saveConfig.handler.ts
+++ b/packages/api/src/trpc/routers/app/saveConfig.handler.ts
@@ -15,7 +15,7 @@ export const saveConfigHandler = async ({ ctx, input }: SaveConfigOptions) => {
     where: (appteamConfig, { eq, and }) =>
       and(
         eq(appteamConfig.appId, input.appId),
-        eq(appteamConfig.teamId, ctx.session.user.activeTeamId),
+        eq(appteamConfig.teamId, ctx.auth.user.activeTeamId),
       ),
     columns: {
       config: true,
@@ -35,7 +35,7 @@ export const saveConfigHandler = async ({ ctx, input }: SaveConfigOptions) => {
       .where(
         and(
           eq(appTeamConfigs.appId, input.appId),
-          eq(appTeamConfigs.teamId, ctx.session.user.activeTeamId),
+          eq(appTeamConfigs.teamId, ctx.auth.user.activeTeamId),
         ),
       );
   }
@@ -45,7 +45,7 @@ export const saveConfigHandler = async ({ ctx, input }: SaveConfigOptions) => {
 
   await ctx.db.insert(appTeamConfigs).values({
     config: parsedInput,
-    teamId: ctx.session.user.activeTeamId,
+    teamId: ctx.auth.user.activeTeamId,
     appId: input.appId,
   });
 };

--- a/packages/api/src/trpc/routers/app/saveUserAppTeamConfig.handler.ts
+++ b/packages/api/src/trpc/routers/app/saveUserAppTeamConfig.handler.ts
@@ -18,8 +18,8 @@ export const saveUserAppTeamConfigHandler = async ({
     where: (userAppTeamConfigs, { eq, and }) =>
       and(
         eq(userAppTeamConfigs.appId, input.appId),
-        eq(userAppTeamConfigs.teamId, ctx.session.user.activeTeamId),
-        eq(userAppTeamConfigs.userId, ctx.session.user.id),
+        eq(userAppTeamConfigs.teamId, ctx.auth.user.activeTeamId),
+        eq(userAppTeamConfigs.userId, ctx.auth.user.id),
       ),
     columns: {
       config: true,
@@ -39,8 +39,8 @@ export const saveUserAppTeamConfigHandler = async ({
       .where(
         and(
           eq(userAppTeamConfigs.appId, input.appId),
-          eq(userAppTeamConfigs.teamId, ctx.session.user.activeTeamId),
-          eq(userAppTeamConfigs.userId, ctx.session.user.id),
+          eq(userAppTeamConfigs.teamId, ctx.auth.user.activeTeamId),
+          eq(userAppTeamConfigs.userId, ctx.auth.user.id),
         ),
       );
   }
@@ -50,8 +50,8 @@ export const saveUserAppTeamConfigHandler = async ({
 
   await ctx.db.insert(userAppTeamConfigs).values({
     config: parsedInput,
-    teamId: ctx.session.user.activeTeamId,
+    teamId: ctx.auth.user.activeTeamId,
     appId: input.appId,
-    userId: ctx.session.user.id,
+    userId: ctx.auth.user.id,
   });
 };

--- a/packages/api/src/trpc/routers/app/todo/create.handler.ts
+++ b/packages/api/src/trpc/routers/app/todo/create.handler.ts
@@ -11,7 +11,7 @@ interface CreateOptions {
 export const createHandler = async ({ ctx, input }: CreateOptions) => {
   await ctx.db.insert(todos).values({
     assignedToUserId: input.assignedToUserId,
-    teamId: ctx.session.user.activeTeamId,
+    teamId: ctx.auth.user.activeTeamId,
     title: input.title,
     description: input.description,
     dueDate: input.dueDate,

--- a/packages/api/src/trpc/routers/app/todo/getAll.handler.ts
+++ b/packages/api/src/trpc/routers/app/todo/getAll.handler.ts
@@ -6,7 +6,7 @@ interface GetAllOptions {
 
 export const getAllHandler = async ({ ctx }: GetAllOptions) => {
   const todos = await ctx.db.query.todos.findMany({
-    where: (todos, { eq }) => eq(todos.teamId, ctx.session.user.activeTeamId),
+    where: (todos, { eq }) => eq(todos.teamId, ctx.auth.user.activeTeamId),
     with: {
       AssignedToUser: {
         columns: {

--- a/packages/api/src/trpc/routers/app/todo/update.handler.ts
+++ b/packages/api/src/trpc/routers/app/todo/update.handler.ts
@@ -21,9 +21,6 @@ export const updateHandler = async ({ ctx, input }: UpdateOptions) => {
       status: input.status,
     })
     .where(
-      and(
-        eq(todos.id, input.id),
-        eq(todos.teamId, ctx.session.user.activeTeamId),
-      ),
+      and(eq(todos.id, input.id), eq(todos.teamId, ctx.auth.user.activeTeamId)),
     );
 };

--- a/packages/api/src/trpc/routers/app/uninstallApp.handler.ts
+++ b/packages/api/src/trpc/routers/app/uninstallApp.handler.ts
@@ -24,7 +24,7 @@ export const uninstallAppHandler = async ({
       .where(
         and(
           eq(appsToTeams.appId, input.appId),
-          eq(appsToTeams.teamId, ctx.session.user.activeTeamId),
+          eq(appsToTeams.teamId, ctx.auth.user.activeTeamId),
         ),
       );
     await tx
@@ -32,7 +32,7 @@ export const uninstallAppHandler = async ({
       .where(
         and(
           eq(teamAppRoles.appId, input.appId),
-          eq(teamAppRoles.teamId, ctx.session.user.activeTeamId),
+          eq(teamAppRoles.teamId, ctx.auth.user.activeTeamId),
         ),
       );
     await tx
@@ -40,17 +40,17 @@ export const uninstallAppHandler = async ({
       .where(
         and(
           eq(appTeamConfigs.appId, input.appId),
-          eq(appTeamConfigs.teamId, ctx.session.user.activeTeamId),
+          eq(appTeamConfigs.teamId, ctx.auth.user.activeTeamId),
         ),
       );
 
     await removeAppData({
       tx,
       appId: input.appId,
-      user: ctx.session.user,
+      user: ctx.auth.user,
     });
     await invalidateUpstashCache("apps", {
-      teamId: ctx.session.user.activeTeamId,
+      teamId: ctx.auth.user.activeTeamId,
     });
   });
 };

--- a/packages/api/src/trpc/routers/auth/getSession.handler.ts
+++ b/packages/api/src/trpc/routers/auth/getSession.handler.ts
@@ -5,5 +5,5 @@ interface GetSessionOptions {
 }
 
 export const getSessionHandler = ({ ctx }: GetSessionOptions) => {
-  return ctx.session;
+  return ctx.auth;
 };

--- a/packages/api/src/trpc/routers/auth/signOut.handler.ts
+++ b/packages/api/src/trpc/routers/auth/signOut.handler.ts
@@ -18,7 +18,7 @@ export const signOutHandler = async ({ ctx, input }: SignOutOptions) => {
       .delete(expoTokens)
       .where(eq(expoTokens.token, input.expoToken));
 
-  await invalidateSession(ctx.session.session.id);
+  await invalidateSession(ctx.auth.session.id);
 
   return { success: true };
 };

--- a/packages/api/src/trpc/routers/team/appRole/getAll.handler.ts
+++ b/packages/api/src/trpc/routers/team/appRole/getAll.handler.ts
@@ -11,7 +11,7 @@ export const getAllHandler = async ({ ctx, input }: GetAllOptions) => {
   return await ctx.db.query.teamAppRoles.findMany({
     where: (role, { and, eq }) =>
       and(
-        eq(role.teamId, ctx.session.user.activeTeamId),
+        eq(role.teamId, ctx.auth.user.activeTeamId),
         eq(role.appId, input.appId),
       ),
     columns: {

--- a/packages/api/src/trpc/routers/team/appRole/getMyRoles.handler.ts
+++ b/packages/api/src/trpc/routers/team/appRole/getMyRoles.handler.ts
@@ -12,14 +12,14 @@ export const getMyRolesHandler = async ({ ctx, input }: GetMyRolesOptions) => {
   const roles = await ctx.db.query.teamAppRoles.findMany({
     where: (teamAppRole, { eq, and, inArray }) =>
       and(
-        eq(teamAppRole.teamId, ctx.session.user.activeTeamId),
+        eq(teamAppRole.teamId, ctx.auth.user.activeTeamId),
         eq(teamAppRole.appId, input.appId),
         inArray(
           teamAppRole.id,
           ctx.db
             .select({ id: teamAppRolesToUsers.teamAppRoleId })
             .from(teamAppRolesToUsers)
-            .where(eq(teamAppRolesToUsers.userId, ctx.session.user.id)),
+            .where(eq(teamAppRolesToUsers.userId, ctx.auth.user.id)),
         ),
       ),
     columns: {

--- a/packages/api/src/trpc/routers/team/appRole/getPermissions.handler.ts
+++ b/packages/api/src/trpc/routers/team/appRole/getPermissions.handler.ts
@@ -16,7 +16,7 @@ export const getPermissionsHandler = async ({
   const teamAppRolesIdsForActiveTeamId = await ctx.db
     .select({ id: teamAppRoles.id })
     .from(teamAppRoles)
-    .where(eq(teamAppRoles.teamId, ctx.session.user.activeTeamId))
+    .where(eq(teamAppRoles.teamId, ctx.auth.user.activeTeamId))
     .then((res) => res.map((r) => r.id));
 
   const permissions = await ctx.db.query.appPermissions.findMany({

--- a/packages/api/src/trpc/routers/team/appRole/getUsersWithRoles.handler.ts
+++ b/packages/api/src/trpc/routers/team/appRole/getUsersWithRoles.handler.ts
@@ -20,7 +20,7 @@ export const getUsersWithRolesHandler = async ({
         ctx.db
           .select({ id: usersToTeams.userId })
           .from(usersToTeams)
-          .where(eq(usersToTeams.teamId, ctx.session.user.activeTeamId)),
+          .where(eq(usersToTeams.teamId, ctx.auth.user.activeTeamId)),
       ),
     with: {
       TeamAppRolesToUsers: {
@@ -32,7 +32,7 @@ export const getUsersWithRolesHandler = async ({
               .from(teamAppRoles)
               .where(
                 and(
-                  eq(teamAppRoles.teamId, ctx.session.user.activeTeamId),
+                  eq(teamAppRoles.teamId, ctx.auth.user.activeTeamId),
                   eq(teamAppRoles.appId, input.appId),
                 ),
               ),

--- a/packages/api/src/trpc/routers/team/appRole/updatePermissionAssociation.handler.ts
+++ b/packages/api/src/trpc/routers/team/appRole/updatePermissionAssociation.handler.ts
@@ -22,7 +22,7 @@ export const updatePermissionAssociationHandler = async ({
           ctx.db
             .select({ id: teamAppRoles.id })
             .from(teamAppRoles)
-            .where(eq(teamAppRoles.teamId, ctx.session.user.activeTeamId)),
+            .where(eq(teamAppRoles.teamId, ctx.auth.user.activeTeamId)),
         ),
       );
     if (input.teamAppRoleIds.length > 0)

--- a/packages/api/src/trpc/routers/team/appRole/updateUserAssociation.handler.ts
+++ b/packages/api/src/trpc/routers/team/appRole/updateUserAssociation.handler.ts
@@ -23,11 +23,11 @@ export const updateUserAssociationHandler = async ({
       .where(
         and(
           eq(teamAppRoles.appId, input.appId),
-          eq(teamAppRoles.teamId, ctx.session.user.activeTeamId),
+          eq(teamAppRoles.teamId, ctx.auth.user.activeTeamId),
         ),
       );
 
-    if (input.userId === ctx.session.user.id) {
+    if (input.userId === ctx.auth.user.id) {
       //need to detect if they are sending the admin role to prevent removing themselves
       const adminTeamAppRolesForApp = await tx
         .select({ id: teamAppRoles.id })

--- a/packages/api/src/trpc/routers/team/create.handler.ts
+++ b/packages/api/src/trpc/routers/team/create.handler.ts
@@ -14,12 +14,10 @@ export const createHandler = async ({ ctx, input }: CreateOptions) => {
   await ctx.db.transaction(async (tx) => {
     const team = await tx.insert(teams).values({
       id: teamId,
-      ownerId: ctx.session.user.id,
+      ownerId: ctx.auth.user.id,
       name: input.teamName,
     });
-    await tx
-      .insert(usersToTeams)
-      .values({ userId: ctx.session.user.id, teamId });
+    await tx.insert(usersToTeams).values({ userId: ctx.auth.user.id, teamId });
     return team;
   });
 

--- a/packages/api/src/trpc/routers/team/deleteTeam.handler.ts
+++ b/packages/api/src/trpc/routers/team/deleteTeam.handler.ts
@@ -53,7 +53,7 @@ export const deleteTeamHandler = async ({ ctx, input }: DeleteTeamOptions) => {
     .where(
       and(
         not(eq(teams.id, input.teamId)),
-        eq(usersToTeams.userId, ctx.session.user.id),
+        eq(usersToTeams.userId, ctx.auth.user.id),
       ),
     )
     .then((res) => res[0]);
@@ -71,7 +71,7 @@ export const deleteTeamHandler = async ({ ctx, input }: DeleteTeamOptions) => {
     await tx
       .update(users)
       .set({ activeTeamId: otherTeam.id })
-      .where(eq(users.id, ctx.session.user.id));
+      .where(eq(users.id, ctx.auth.user.id));
 
     //Remove the team
     await tx.delete(careTasks).where(eq(careTasks.teamId, input.teamId)); //?uuuuh...

--- a/packages/api/src/trpc/routers/team/getActiveTeam.handler.ts
+++ b/packages/api/src/trpc/routers/team/getActiveTeam.handler.ts
@@ -33,8 +33,8 @@ const prepared = db.query.teams
 
 export const getActiveTeamHandler = async ({ ctx }: GetActiveTeamOptions) => {
   const team = await prepared.execute({
-    teamId: ctx.session.user.activeTeamId,
-    userId: ctx.session.user.id,
+    teamId: ctx.auth.user.activeTeamId,
+    userId: ctx.auth.user.id,
   });
 
   if (!team) {

--- a/packages/api/src/trpc/routers/team/getAll.ts
+++ b/packages/api/src/trpc/routers/team/getAll.ts
@@ -24,7 +24,7 @@ export const getAllHandler = async ({ ctx }: GetAllOptions) => {
           .where(
             and(
               eq(usersToTeams.teamId, teams.id),
-              eq(usersToTeams.userId, ctx.session.user.id),
+              eq(usersToTeams.userId, ctx.auth.user.id),
             ),
           ),
       ),

--- a/packages/api/src/trpc/routers/team/getAllUsers.handler.ts
+++ b/packages/api/src/trpc/routers/team/getAllUsers.handler.ts
@@ -16,6 +16,6 @@ export const getAllUsersHandler = async ({ ctx }: GetAllUsersOptions) => {
       image: users.image,
     })
     .from(users)
-    .where(eq(usersToTeams.teamId, ctx.session.user.activeTeamId))
+    .where(eq(usersToTeams.teamId, ctx.auth.user.activeTeamId))
     .innerJoin(usersToTeams, eq(usersToTeams.userId, users.id));
 };

--- a/packages/api/src/trpc/routers/team/invitation/accept.handler.ts
+++ b/packages/api/src/trpc/routers/team/invitation/accept.handler.ts
@@ -11,8 +11,8 @@ interface AcceptOptions {
 export const acceptHandler = async ({ ctx, input }: AcceptOptions) => {
   await acceptInvite({
     invite: input.invitationId,
-    userId: ctx.session.user.id,
-    email: ctx.session.user.email,
+    userId: ctx.auth.user.id,
+    email: ctx.auth.user.email,
     db: ctx.db,
   });
 };

--- a/packages/api/src/trpc/routers/team/invitation/decline.handler.ts
+++ b/packages/api/src/trpc/routers/team/invitation/decline.handler.ts
@@ -17,7 +17,7 @@ export const declineHandler = async ({ ctx, input }: DeclineOptions) => {
     where: (invitation, { and, eq }) =>
       and(
         eq(invitation.id, input.invitationId),
-        eq(invitation.email, ctx.session.user.email),
+        eq(invitation.email, ctx.auth.user.email),
       ),
   });
   const t = await getTranslations({ locale: ctx.locale });

--- a/packages/api/src/trpc/routers/team/invitation/delete.handler.ts
+++ b/packages/api/src/trpc/routers/team/invitation/delete.handler.ts
@@ -17,7 +17,7 @@ export const deleteHandler = async ({ ctx, input }: DeleteOptions) => {
     where: (invitation, { eq }) =>
       and(
         eq(invitation.id, input.invitationId),
-        eq(invitation.teamId, ctx.session.user.activeTeamId),
+        eq(invitation.teamId, ctx.auth.user.activeTeamId),
       ),
   });
 

--- a/packages/api/src/trpc/routers/team/invitation/getAll.handler.ts
+++ b/packages/api/src/trpc/routers/team/invitation/getAll.handler.ts
@@ -7,7 +7,7 @@ interface GetAllOptions {
 export const getAllHandler = async ({ ctx }: GetAllOptions) => {
   const invitations = await ctx.db.query.invitations.findMany({
     where: (invitation, { eq }) =>
-      eq(invitation.teamId, ctx.session.user.activeTeamId),
+      eq(invitation.teamId, ctx.auth.user.activeTeamId),
     columns: {
       id: true,
       email: true,

--- a/packages/api/src/trpc/routers/team/invitation/invite.handler.ts
+++ b/packages/api/src/trpc/routers/team/invitation/invite.handler.ts
@@ -30,7 +30,7 @@ export const inviteHandler = async ({ ctx, input }: InviteOptions) => {
     with: {
       UsersToTeams: {
         // where: (usersToTeams, { eq }) =>
-        //   eq(usersToTeams.userId, ctx.session.user.id),
+        //   eq(usersToTeams.userId, ctx.auth.user.id),
         with: {
           User: {
             columns: {
@@ -81,7 +81,7 @@ export const inviteHandler = async ({ ctx, input }: InviteOptions) => {
         id: nanoid(),
         teamId: team.id,
         email,
-        invitedById: ctx.session.user.id,
+        invitedById: ctx.auth.user.id,
       }) satisfies typeof invitations.$inferInsert,
   );
 
@@ -94,8 +94,8 @@ export const inviteHandler = async ({ ctx, input }: InviteOptions) => {
           url: getBaseUrl(),
         }),
         react: TeamInvite({
-          invitedByEmail: ctx.session.user.email,
-          invitedByUsername: ctx.session.user.name!,
+          invitedByEmail: ctx.auth.user.email,
+          invitedByUsername: ctx.auth.user.name!,
           inviteLink: `${getBaseUrl()}/team/invite/${invite.id}`,
           teamImage: `${getBaseUrl()}/api/avatar/${team.name}`,
           teamName: team.name,

--- a/packages/api/src/trpc/routers/team/leaveTeam.handler.ts
+++ b/packages/api/src/trpc/routers/team/leaveTeam.handler.ts
@@ -32,7 +32,7 @@ export const leaveTeamHandler = async ({ ctx, input }: LeaveTeamOptions) => {
       message: t("api.No Team Found"),
     });
 
-  if (team.ownerId === ctx.session.user.id)
+  if (team.ownerId === ctx.auth.user.id)
     throw new TRPCError({
       code: "FORBIDDEN",
       message: t(
@@ -46,8 +46,8 @@ export const leaveTeamHandler = async ({ ctx, input }: LeaveTeamOptions) => {
     .innerJoin(usersToTeams, eq(teams.id, usersToTeams.teamId))
     .where(
       and(
-        not(eq(teams.id, ctx.session.user.activeTeamId)),
-        eq(usersToTeams.userId, ctx.session.user.id),
+        not(eq(teams.id, ctx.auth.user.activeTeamId)),
+        eq(usersToTeams.userId, ctx.auth.user.id),
       ),
     )
     .then((res) => res[0]);
@@ -66,7 +66,7 @@ export const leaveTeamHandler = async ({ ctx, input }: LeaveTeamOptions) => {
     await tx
       .update(users)
       .set({ activeTeamId: otherTeam.id })
-      .where(eq(users.id, ctx.session.user.id));
+      .where(eq(users.id, ctx.auth.user.id));
 
     //Remove the user from the team
     await tx
@@ -74,7 +74,7 @@ export const leaveTeamHandler = async ({ ctx, input }: LeaveTeamOptions) => {
       .where(
         and(
           eq(usersToTeams.teamId, input.teamId),
-          eq(usersToTeams.userId, ctx.session.user.id),
+          eq(usersToTeams.userId, ctx.auth.user.id),
         ),
       );
 
@@ -83,7 +83,7 @@ export const leaveTeamHandler = async ({ ctx, input }: LeaveTeamOptions) => {
       .delete(teamAppRolesToUsers)
       .where(
         and(
-          eq(teamAppRolesToUsers.userId, ctx.session.user.id),
+          eq(teamAppRolesToUsers.userId, ctx.auth.user.id),
           inArray(
             teamAppRolesToUsers.teamAppRoleId,
             ctx.db

--- a/packages/api/src/trpc/routers/team/removeUser.handler.ts
+++ b/packages/api/src/trpc/routers/team/removeUser.handler.ts
@@ -20,7 +20,7 @@ interface RemoveUserOptions {
 }
 
 export const removeUserHandler = async ({ ctx, input }: RemoveUserOptions) => {
-  const isUserTryingToRemoveSelfFromTeam = input.userId === ctx.session.user.id;
+  const isUserTryingToRemoveSelfFromTeam = input.userId === ctx.auth.user.id;
   if (isUserTryingToRemoveSelfFromTeam) {
     const t = await getTranslations({ locale: ctx.locale });
     throw new TRPCError({
@@ -37,7 +37,7 @@ export const removeUserHandler = async ({ ctx, input }: RemoveUserOptions) => {
     .innerJoin(usersToTeams, eq(teams.id, usersToTeams.teamId))
     .where(
       and(
-        not(eq(teams.id, ctx.session.user.activeTeamId)),
+        not(eq(teams.id, ctx.auth.user.activeTeamId)),
         eq(usersToTeams.userId, input.userId),
       ),
     )
@@ -74,7 +74,7 @@ export const removeUserHandler = async ({ ctx, input }: RemoveUserOptions) => {
       .where(
         and(
           eq(usersToTeams.userId, input.userId),
-          eq(usersToTeams.teamId, ctx.session.user.activeTeamId),
+          eq(usersToTeams.teamId, ctx.auth.user.activeTeamId),
         ),
       );
 
@@ -89,7 +89,7 @@ export const removeUserHandler = async ({ ctx, input }: RemoveUserOptions) => {
             ctx.db
               .select({ id: teamAppRoles.id })
               .from(teamAppRoles)
-              .where(eq(teamAppRoles.teamId, ctx.session.user.activeTeamId)),
+              .where(eq(teamAppRoles.teamId, ctx.auth.user.activeTeamId)),
           ),
         ),
       );

--- a/packages/api/src/trpc/routers/user/changeName.handler.ts
+++ b/packages/api/src/trpc/routers/user/changeName.handler.ts
@@ -13,5 +13,5 @@ export const changeNameHandler = async ({ ctx, input }: ChangeNameOptions) => {
   return await ctx.db
     .update(users)
     .set({ name: input.name })
-    .where(eq(users.id, ctx.session.user.id));
+    .where(eq(users.id, ctx.auth.user.id));
 };

--- a/packages/api/src/trpc/routers/user/deleteAccount.handler.ts
+++ b/packages/api/src/trpc/routers/user/deleteAccount.handler.ts
@@ -30,7 +30,7 @@ export const deleteAccountHandler = async ({ ctx }: DeleteAccountOptions) => {
           .where(
             and(
               eq(usersToTeams.teamId, teams.id),
-              eq(usersToTeams.userId, ctx.session.user.id),
+              eq(usersToTeams.userId, ctx.auth.user.id),
             ),
           ),
       ),
@@ -58,12 +58,12 @@ export const deleteAccountHandler = async ({ ctx }: DeleteAccountOptions) => {
     });
 
   await ctx.db.transaction(async (tx) => {
-    await tx.delete(accounts).where(eq(accounts.userId, ctx.session.user.id));
+    await tx.delete(accounts).where(eq(accounts.userId, ctx.auth.user.id));
     await tx
       .delete(invitations)
-      .where(eq(invitations.invitedById, ctx.session.user.id));
-    await tx.delete(teams).where(eq(teams.ownerId, ctx.session.user.id));
-    await tx.delete(sessions).where(eq(sessions.userId, ctx.session.user.id));
-    await tx.delete(users).where(eq(users.id, ctx.session.user.id));
+      .where(eq(invitations.invitedById, ctx.auth.user.id));
+    await tx.delete(teams).where(eq(teams.ownerId, ctx.auth.user.id));
+    await tx.delete(sessions).where(eq(sessions.userId, ctx.auth.user.id));
+    await tx.delete(users).where(eq(users.id, ctx.auth.user.id));
   });
 };

--- a/packages/api/src/trpc/routers/user/deleteNotifications.handler.ts
+++ b/packages/api/src/trpc/routers/user/deleteNotifications.handler.ts
@@ -17,7 +17,7 @@ export const deleteNotificationsHandler = async ({
     .delete(notifications)
     .where(
       and(
-        eq(notifications.sentToUserId, ctx.session.user.id),
+        eq(notifications.sentToUserId, ctx.auth.user.id),
         inArray(notifications.id, input.ids),
       ),
     );

--- a/packages/api/src/trpc/routers/user/getInvitations.handler.ts
+++ b/packages/api/src/trpc/routers/user/getInvitations.handler.ts
@@ -34,7 +34,7 @@ const prepared = db.query.invitations
 
 export const getInvitationsHandler = async ({ ctx }: GetInvitationsOptions) => {
   const invitations = await prepared.execute({
-    email: ctx.session.user.email,
+    email: ctx.auth.user.email,
   });
 
   return invitations;

--- a/packages/api/src/trpc/routers/user/getNotifications.handler.tsx
+++ b/packages/api/src/trpc/routers/user/getNotifications.handler.tsx
@@ -35,7 +35,7 @@ export const getNotificationsHandler = async ({
   const allTeamIdsForUserQuery = ctx.db
     .select({ id: usersToTeams.teamId })
     .from(usersToTeams)
-    .where(eq(usersToTeams.userId, ctx.session.user.id));
+    .where(eq(usersToTeams.userId, ctx.auth.user.id));
 
   const filterExpressions: (SQL<unknown> | undefined)[] = [
     // Filter notifications by subject
@@ -71,7 +71,7 @@ export const getNotificationsHandler = async ({
   ];
 
   const where: DrizzleWhere<typeof notifications.$inferSelect> = and(
-    eq(notifications.sentToUserId, ctx.session.user.id), //? Only show notifications for the logged in user
+    eq(notifications.sentToUserId, ctx.auth.user.id), //? Only show notifications for the logged in user
     inArray(notifications.teamId, allTeamIdsForUserQuery), //? Ensure user is part of the team
 
     !input.operator || input.operator === "and"

--- a/packages/api/src/trpc/routers/user/notifications/saveExpoToken.handler.ts
+++ b/packages/api/src/trpc/routers/user/notifications/saveExpoToken.handler.ts
@@ -14,6 +14,6 @@ export const saveExpoTokenHandler = async ({
 }: SaveExpoTokenOptions) => {
   await ctx.db.insert(expoTokens).values({
     token: input.expoToken,
-    userId: ctx.session.user.id,
+    userId: ctx.auth.user.id,
   });
 };

--- a/packages/api/src/trpc/routers/user/switchActiveTeam.handler.ts
+++ b/packages/api/src/trpc/routers/user/switchActiveTeam.handler.ts
@@ -14,7 +14,7 @@ export const switchActiveTeamHandler = async ({
 }: SwitchActiveTeamOptions) => {
   await switchActiveTeamForUser({
     db: ctx.db,
-    userId: ctx.session.user.id,
+    userId: ctx.auth.user.id,
     teamId: input.teamId,
   });
 };

--- a/packages/api/src/trpc/trpc.ts
+++ b/packages/api/src/trpc/trpc.ts
@@ -31,16 +31,16 @@ import { getLocaleBasedOnCookie } from "../utils/locales";
  */
 export const createTRPCContext = (opts: {
   headers: Headers;
-  session: AuthResponse | null;
+  auth: AuthResponse;
 }) => {
   const authToken = opts.headers.get("Authorization") ?? null;
-  const session = opts.session;
+  const auth = opts.auth;
 
   const source = opts.headers.get("x-trpc-source") ?? "unknown";
-  console.log(">>> tRPC Request from", source, "by", session?.user);
+  console.log(">>> tRPC Request from", source, "by", auth.user);
   return {
     locale: getLocaleBasedOnCookie(),
-    session,
+    auth,
     db,
     token: authToken,
   };


### PR DESCRIPTION
This pull request updates the codebase to replace all instances of `session` with `auth`, ensuring a consistent naming convention throughout the application. This change enhances clarity and aligns with the updated authentication strategy. All relevant handlers and context creation methods have been modified accordingly.